### PR TITLE
0.1.52

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "approx"
@@ -1921,7 +1921,7 @@ checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 
 [[package]]
 name = "curvo"
-version = "0.1.51"
+version = "0.1.52"
 dependencies = [
  "anyhow",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curvo"
-version = "0.1.51"
+version = "0.1.52"
 authors = ["Masatatsu Nakamura <masatatsu.nakamura@gmail.com"]
 edition = "2021"
 keywords = ["nurbs", "modeling", "graphics", "3d"]
@@ -12,7 +12,7 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-anyhow = "1.0.97"
+anyhow = "1.0.98"
 nalgebra = { version = "0.33.2", features = ["serde-serialize"] }
 num-traits = "0.2.19"
 rand = "0.9.0"

--- a/src/surface/nurbs_surface.rs
+++ b/src/surface/nurbs_surface.rs
@@ -828,7 +828,7 @@ where
         let (u_start, u_end) = self.u_knots_domain();
         let (v_start, v_end) = self.v_knots_domain();
         Ok([
-            // clock-wised order
+            // clockwise order
             self.try_isocurve(u_start, UVDirection::U)?, // v along (00 to 01)
             self.try_isocurve(v_end, UVDirection::V)?,   // u along (01 to 11)
             self.try_isocurve(u_end, UVDirection::U)?.inverse(), // v along (11 to 10)


### PR DESCRIPTION
- Modified the `try_boundary_curves` API for `NURBSSurface` so that a result with consistent orientation is obtained (the four returned iso curves now form a loop according to the revised specification).