### PR TITLE
0.1.55

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2071,7 +2071,7 @@ checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 
 [[package]]
 name = "curvo"
-version = "0.1.54"
+version = "0.1.55"
 dependencies = [
  "anyhow",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curvo"
-version = "0.1.54"
+version = "0.1.55"
 authors = ["Masatatsu Nakamura <masatatsu.nakamura@gmail.com"]
 edition = "2021"
 keywords = ["nurbs", "modeling", "graphics", "3d"]

--- a/examples/offset_curve.rs
+++ b/examples/offset_curve.rs
@@ -33,9 +33,9 @@ impl Default for Setting {
             corner_type: CurveOffsetCornerType::Round,
             // corner_type: CurveOffsetCornerType::Smooth,
             distance: 0.2,
+            // distance: -0.2,
             // distance: 2.0,
             degree: 1,
-            // distance: -0.2,
         }
     }
 }
@@ -134,7 +134,7 @@ fn setup(mut commands: Commands, settings: Res<Setting>) {
 
     let curve = NurbsCurve2D::polyline(&points, true);
     let option = CurveOffsetOption::default()
-        .with_corner_type(CurveOffsetCornerType::Round)
+        .with_corner_type(settings.corner_type)
         .with_distance(settings.distance)
         .with_normal_tolerance(1e-4);
     let offset_curve = curve.offset(option.clone()).unwrap();
@@ -250,7 +250,7 @@ fn update_ui(
 
         let mut offset_curve = offset_curve.single_mut().unwrap();
         let option = CurveOffsetOption::default()
-            .with_corner_type(settings.corner_type.clone())
+            .with_corner_type(settings.corner_type)
             .with_distance(settings.distance)
             .with_normal_tolerance(1e-4);
         let res = profile.0.offset(option);

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -2,7 +2,8 @@ pub mod offset_nurbs_curve;
 pub use offset_nurbs_curve::*;
 
 /// Corner type for offsetting NURBS curves
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum CurveOffsetCornerType {
     /// Just offset the curve segments
     None,

--- a/src/offset/offset_nurbs_curve.rs
+++ b/src/offset/offset_nurbs_curve.rs
@@ -574,4 +574,62 @@ mod tests {
             ]
         );
     }
+
+    #[test]
+    fn offset_closed_rectangle() {
+        let points = vec![
+            Point2::new(0.0, 0.0),
+            Point2::new(1.0, 0.0),
+            Point2::new(1.0, 1.0),
+            Point2::new(0.0, 1.0),
+            Point2::new(0.0, 0.0),
+        ];
+        let polyline = NurbsCurve2D::polyline(&points, false);
+        let option = CurveOffsetOption {
+            distance: 0.2,
+            corner_type: CurveOffsetCornerType::Sharp,
+            ..Default::default()
+        };
+
+        // positive offset
+        let res = polyline.offset(option.clone()).unwrap();
+        assert_eq!(res.len(), 1);
+        let curve = &res[0];
+        let spans = curve.spans();
+        assert_eq!(spans.len(), 1);
+        let span = &spans[0];
+        let pts = span.dehomogenized_control_points();
+        assert_eq!(pts.len(), 5);
+        assert_eq!(
+            pts,
+            vec![
+                Point2::new(-0.2, -0.2),
+                Point2::new(1.2, -0.2),
+                Point2::new(1.2, 1.2),
+                Point2::new(-0.2, 1.2),
+                Point2::new(-0.2, -0.2),
+            ]
+        );
+
+        // negative offset
+        let option = option.clone().with_distance(-0.2);
+        let res = polyline.offset(option).unwrap();
+        assert_eq!(res.len(), 1);
+        let curve = &res[0];
+        let spans = curve.spans();
+        assert_eq!(spans.len(), 1);
+        let span = &spans[0];
+        let pts = span.dehomogenized_control_points();
+        assert_eq!(pts.len(), 5);
+        assert_eq!(
+            pts,
+            vec![
+                Point2::new(0.2, 0.2),
+                Point2::new(0.8, 0.2),
+                Point2::new(0.8, 0.8),
+                Point2::new(0.2, 0.8),
+                Point2::new(0.2, 0.2),
+            ]
+        );
+    }
 }

--- a/src/offset/offset_nurbs_curve.rs
+++ b/src/offset/offset_nurbs_curve.rs
@@ -201,6 +201,7 @@ where
                     let delta = distance.abs() * T::from_f64(2.0).unwrap();
 
                     let n = segments.len();
+
                     let pts = segments
                         .iter()
                         .enumerate()
@@ -238,7 +239,7 @@ where
                                     Some(*p)
                                 }
                             }
-                            _ => None,
+                            Vertex::Intersection(opoint) => Some(*opoint),
                         }
                     } else {
                         None


### PR DESCRIPTION
This pull request includes updates to the `curvo` package version, improvements to the handling of offset curves in the codebase, and the addition of a new test for offsetting closed rectangles. The most significant changes involve enhancements to the `CurveOffsetCornerType` enum, adjustments to the offset curve logic, and the introduction of a new test case to verify functionality.

### Package Version Update:
* Updated the `curvo` package version from `0.1.54` to `0.1.55` in `Cargo.toml`.

### Enhancements to Offset Curve Handling:
* Modified the `CurveOffsetCornerType` enum to derive `Copy` and added support for serialization and deserialization when the `serde` feature is enabled.
* Improved the handling of intersection vertices in offset curve logic by ensuring the correct point is returned.

### Code Refinements:
* Adjusted the `examples/offset_curve.rs` file to use `settings.corner_type` and `settings.distance` consistently in multiple functions, improving code readability and maintainability. [[1]](diffhunk://#diff-ef22c7ae507466a9c0a35c489b040842c3dd005bb602ffcc08aab4162ac1a5d7R36-L38) [[2]](diffhunk://#diff-ef22c7ae507466a9c0a35c489b040842c3dd005bb602ffcc08aab4162ac1a5d7L137-R137) [[3]](diffhunk://#diff-ef22c7ae507466a9c0a35c489b040842c3dd005bb602ffcc08aab4162ac1a5d7L253-R253)

### New Test Case for Offset Functionality:
* Added a comprehensive test for offsetting closed rectangles, verifying both positive and negative offsets and ensuring the correctness of control points. This test improves confidence in the offset functionality.