### PR TITLE
0.1.57

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2071,7 +2071,7 @@ checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 
 [[package]]
 name = "curvo"
-version = "0.1.56"
+version = "0.1.57"
 dependencies = [
  "anyhow",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,3 +192,8 @@ required-features = ["bevy"]
 name = "offset_compound_curve"
 path = "examples/offset_compound_curve.rs"
 required-features = ["bevy"]
+
+[[example]]
+name = "fillet_curve"
+path = "examples/fillet_curve.rs"
+required-features = ["bevy"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curvo"
-version = "0.1.56"
+version = "0.1.57"
 authors = ["Masatatsu Nakamura <masatatsu.nakamura@gmail.com"]
 edition = "2021"
 keywords = ["nurbs", "modeling", "graphics", "3d"]

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ The supported features also include finding the closest point on NURBS curves, f
 
 <img src="https://github.com/user-attachments/assets/6b0583e4-01d4-447e-9347-c7b8bd0bc8af" width="360px" alt="Offset curve" />
 
+<img src="https://github.com/user-attachments/assets/4514e075-6e36-458e-867d-581d6bba62f7" width="360px" alt="Fillet curve" />
+
 ## Usage
 
 ```rust

--- a/examples/fillet_curve.rs
+++ b/examples/fillet_curve.rs
@@ -330,13 +330,16 @@ fn gizmos_curve(
     match settings.dimension {
         Dimension::Two => {
             let profile = profile.single().unwrap();
-            let tess = profile
-                .0
-                .tessellate(Some(tol))
-                .into_iter()
-                .map(|p| p.coords.cast::<f32>().to_homogeneous().into())
-                .collect_vec();
-            gizmos.linestrip(tess, WHITE.with_alpha(0.25));
+
+            if !settings.use_parameter {
+                let tess = profile
+                    .0
+                    .tessellate(Some(tol))
+                    .into_iter()
+                    .map(|p| p.coords.cast::<f32>().to_homogeneous().into())
+                    .collect_vec();
+                gizmos.linestrip(tess, WHITE.with_alpha(0.25));
+            }
 
             let fillet_curve = fillet_curve.single().unwrap();
             fillet_curve.0.spans().iter().for_each(|c| {

--- a/examples/fillet_curve.rs
+++ b/examples/fillet_curve.rs
@@ -112,7 +112,7 @@ fn setup(mut commands: Commands, settings: Res<Setting>) {
     ];
 
     // square
-    let points = vec![
+    let _points = vec![
         Point2::new(-1.0, -1.0),
         Point2::new(1.0, -1.0),
         Point2::new(1.0, 1.0),
@@ -137,7 +137,10 @@ fn setup(mut commands: Commands, settings: Res<Setting>) {
     .collect_vec();
 
     let mut rng: rand::rngs::StdRng = rand::SeedableRng::from_seed([0; 32]);
-    let delta = 0.5;
+    let delta = 1.0;
+
+    /*
+    // wobble the points for debugging
     let points = points
         .into_iter()
         .map(|p| {
@@ -146,6 +149,7 @@ fn setup(mut commands: Commands, settings: Res<Setting>) {
             Point2::new(p.x + dx, p.y + dy)
         })
         .collect_vec();
+    */
 
     commands.spawn((ControlPoints(points.clone()),));
 
@@ -267,23 +271,23 @@ fn gizmos_curve(
 ) {
     let points = &control_points.single().unwrap().0;
     points.iter().for_each(|p| {
-        let p: Vec3 = p.coords.cast::<f32>().to_homogeneous().into();
+        let _p: Vec3 = p.coords.cast::<f32>().to_homogeneous().into();
         // gizmos.sphere(p, 0.025, WHITE);
     });
 
     let tol = 1e-7 * 0.5;
 
-    let profile = profile.single().unwrap();
-    let tess = profile
-        .0
-        .tessellate(Some(tol))
-        .into_iter()
-        .map(|p| p.coords.cast::<f32>().to_homogeneous().into())
-        .collect_vec();
-    gizmos.linestrip(tess, WHITE.with_alpha(0.25));
-
     match settings.dimension {
         Dimension::Two => {
+            let profile = profile.single().unwrap();
+            let tess = profile
+                .0
+                .tessellate(Some(tol))
+                .into_iter()
+                .map(|p| p.coords.cast::<f32>().to_homogeneous().into())
+                .collect_vec();
+            gizmos.linestrip(tess, WHITE.with_alpha(0.25));
+
             let fillet_curve = fillet_curve.single().unwrap();
             fillet_curve.0.spans().iter().for_each(|c| {
                 let tess: Vec<Vec3> = c

--- a/examples/fillet_curve.rs
+++ b/examples/fillet_curve.rs
@@ -1,0 +1,334 @@
+use bevy::{
+    color::palettes::css::{BLUE, LIGHT_GREEN, WHITE, YELLOW},
+    prelude::*,
+    render::camera::ScalingMode,
+};
+use bevy_egui::{egui, EguiContextPass, EguiContexts, EguiPlugin};
+use bevy_infinite_grid::InfiniteGridPlugin;
+
+use bevy_panorbit_camera::{PanOrbitCamera, PanOrbitCameraPlugin};
+use bevy_points::plugin::PointsPlugin;
+use itertools::Itertools;
+use nalgebra::Point2;
+
+use curvo::prelude::*;
+
+mod materials;
+mod misc;
+
+use materials::*;
+use misc::*;
+
+#[derive(Resource, Debug)]
+struct Setting {
+    pub corner_type: CurveOffsetCornerType,
+    pub distance: f64,
+    pub degree: usize,
+}
+
+impl Default for Setting {
+    fn default() -> Self {
+        Self {
+            // corner_type: CurveOffsetCornerType::Sharp,
+            corner_type: CurveOffsetCornerType::Round,
+            // corner_type: CurveOffsetCornerType::Smooth,
+            distance: 0.2,
+            // distance: -0.2,
+            // distance: 2.0,
+            degree: 1,
+        }
+    }
+}
+
+#[derive(Component)]
+struct ControlPoints(pub Vec<Point2<f64>>);
+
+#[derive(Component)]
+struct ProfileCurve(pub NurbsCurve2D<f64>);
+
+#[derive(Component)]
+struct OffsetVertex(pub Vec<CompoundCurve2D<f64>>);
+
+#[derive(Component)]
+struct OffsetCurve(pub Vec<CompoundCurve2D<f64>>);
+
+impl OffsetCurve {
+    pub fn update(&mut self, entities: Vec<CompoundCurve2D<f64>>) {
+        self.0 = entities;
+    }
+}
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            primary_window: Some(Window {
+                resolution: (640., 480.).into(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }))
+        .add_plugins(LineMaterialPlugin)
+        .add_plugins(InfiniteGridPlugin)
+        .add_plugins(PanOrbitCameraPlugin)
+        .add_plugins(PointsPlugin)
+        .add_plugins(EguiPlugin {
+            enable_multipass_for_primary_context: true,
+        })
+        .add_plugins(AppPlugin)
+        .run();
+}
+struct AppPlugin;
+
+impl Plugin for AppPlugin {
+    fn build(&self, app: &mut bevy::prelude::App) {
+        app.insert_resource(Setting::default())
+            .add_systems(Startup, setup)
+            .add_systems(
+                PreUpdate,
+                (absorb_egui_inputs,)
+                    .after(bevy_egui::input::write_egui_input_system)
+                    .before(bevy_egui::begin_pass_system),
+            )
+            .add_systems(EguiContextPass, update_ui)
+            .add_systems(Update, gizmos_offset_curve);
+    }
+}
+
+fn setup(mut commands: Commands, settings: Res<Setting>) {
+    // s-shape
+    let _points = [
+        Point2::new(-1.0, -1.0),
+        Point2::new(1.0, -1.0),
+        Point2::new(1.0, 1.0),
+        Point2::new(-1.0, 1.0),
+        Point2::new(-1.0, 3.0),
+        Point2::new(1.0, 3.0),
+    ];
+
+    // square
+    let _points = [
+        Point2::new(-1.0, -1.0),
+        Point2::new(1.0, -1.0),
+        Point2::new(1.0, 1.0),
+        Point2::new(-1.0, 1.0),
+        Point2::new(-1.0, -1.0),
+    ];
+
+    // convex polygon
+    let points = vec![
+        Point2::new(-0.5, 2.),
+        Point2::new(0.5, 2.),
+        Point2::new(0.5, 1.),
+        Point2::new(1.5, 1.),
+        Point2::new(1.5, -1.),
+        Point2::new(-1.5, -1.),
+        Point2::new(-1.5, 1.),
+        Point2::new(-0.5, 1.),
+        Point2::new(-0.5, 2.),
+    ]
+    .into_iter()
+    .rev()
+    .collect_vec();
+
+    commands.spawn((ControlPoints(points.clone()),));
+
+    let curve = NurbsCurve2D::polyline(&points, true);
+    let option = CurveOffsetOption::default()
+        .with_corner_type(settings.corner_type)
+        .with_distance(settings.distance)
+        .with_normal_tolerance(1e-4);
+    let offset_curve = curve.offset(option.clone()).unwrap();
+    let offset_curve_vertex = curve
+        .offset(option.clone().with_corner_type(CurveOffsetCornerType::None))
+        .unwrap();
+
+    commands.spawn((ProfileCurve(curve),));
+    commands.spawn((OffsetCurve(offset_curve),));
+    commands.spawn((OffsetVertex(offset_curve_vertex),));
+
+    let scale = 5.;
+    commands.spawn((
+        Projection::Orthographic(OrthographicProjection {
+            scale,
+            near: 1e-1,
+            far: 1e4,
+            scaling_mode: ScalingMode::FixedVertical {
+                viewport_height: 2.,
+            },
+            ..OrthographicProjection::default_3d()
+        }),
+        Transform::from_translation(Vec3::new(0., 0., 3.)).looking_at(Vec3::ZERO, Vec3::Y),
+        PanOrbitCamera {
+            orbit_sensitivity: 0.0,
+            ..Default::default()
+        },
+    ));
+}
+
+fn update_ui(
+    mut contexts: EguiContexts,
+    mut settings: ResMut<Setting>,
+    control_points: Query<&ControlPoints>,
+    mut profile: Query<&mut ProfileCurve>,
+    mut offset_curve: Query<&mut OffsetCurve>,
+    mut offset_vertex: Query<&mut OffsetVertex>,
+) {
+    let mut changed = false;
+    egui::Window::new("offset curve")
+        .collapsible(false)
+        .drag_to_scroll(false)
+        .default_width(420.)
+        .min_width(420.)
+        .max_width(420.)
+        .show(contexts.ctx_mut(), |ui| {
+            ui.heading("corner type");
+            ui.group(|g| {
+                g.horizontal(|ui| {
+                    changed |= ui
+                        .selectable_value(
+                            &mut settings.corner_type,
+                            CurveOffsetCornerType::Sharp,
+                            "Sharp",
+                        )
+                        .changed();
+                    changed |= ui
+                        .selectable_value(
+                            &mut settings.corner_type,
+                            CurveOffsetCornerType::Round,
+                            "Round",
+                        )
+                        .changed();
+                    changed |= ui
+                        .selectable_value(
+                            &mut settings.corner_type,
+                            CurveOffsetCornerType::Smooth,
+                            "Smooth",
+                        )
+                        .changed();
+                    changed |= ui
+                        .selectable_value(
+                            &mut settings.corner_type,
+                            CurveOffsetCornerType::Chamfer,
+                            "Chamfer",
+                        )
+                        .changed();
+                });
+            });
+
+            ui.heading("distance");
+            ui.group(|g| {
+                g.horizontal(|ui| {
+                    changed |= ui
+                        .add(egui::DragValue::new(&mut settings.distance).speed(1e-2))
+                        .changed();
+                });
+            });
+
+            ui.heading("degree");
+            ui.group(|g| {
+                g.horizontal(|ui| {
+                    changed |= ui.selectable_value(&mut settings.degree, 1, "1").changed();
+                    changed |= ui.selectable_value(&mut settings.degree, 3, "3").changed();
+                });
+            });
+        });
+
+    if changed {
+        let points = &control_points.single().unwrap().0;
+
+        let mut profile = profile.single_mut().unwrap();
+        let n = points.len();
+        let is_closed = points[0] == points[n - 1];
+
+        profile.0 = if is_closed {
+            let points = points.iter().take(n - 1).cloned().collect_vec();
+            NurbsCurve2D::try_periodic_interpolate(&points, settings.degree, KnotStyle::Centripetal)
+                .unwrap()
+        } else {
+            NurbsCurve2D::try_interpolate(points, settings.degree).unwrap()
+        };
+
+        let mut offset_curve = offset_curve.single_mut().unwrap();
+        let option = CurveOffsetOption::default()
+            .with_corner_type(settings.corner_type)
+            .with_distance(settings.distance)
+            .with_normal_tolerance(1e-4);
+        let res = profile.0.offset(option);
+        if let Ok(res) = res {
+            offset_curve.update(res);
+        }
+
+        let option = CurveOffsetOption::default()
+            .with_corner_type(CurveOffsetCornerType::None)
+            .with_distance(settings.distance)
+            .with_normal_tolerance(1e-4);
+        let res = profile.0.offset(option);
+        if let Ok(res) = res {
+            offset_vertex.single_mut().unwrap().0 = res;
+        }
+    }
+}
+
+fn gizmos_offset_curve(
+    control_points: Query<&ControlPoints>,
+    profile: Query<&ProfileCurve>,
+    offset_curve: Query<&OffsetCurve>,
+    _offset_vertex: Query<&OffsetVertex>,
+    mut gizmos: Gizmos,
+) {
+    let points = &control_points.single().unwrap().0;
+    points.iter().for_each(|p| {
+        let p: Vec3 = p.coords.cast::<f32>().to_homogeneous().into();
+        gizmos.sphere(p, 0.025, WHITE);
+    });
+
+    let tol = 1e-7 * 0.5;
+
+    let profile = profile.single().unwrap();
+    let tess = profile
+        .0
+        .tessellate(Some(tol))
+        .into_iter()
+        .map(|p| p.coords.cast::<f32>().to_homogeneous().into())
+        .collect_vec();
+    gizmos.linestrip(tess, WHITE);
+
+    let offset_curve = offset_curve.single().unwrap();
+
+    offset_curve.0.iter().for_each(|c| {
+        let tess = c
+            .tessellate(Some(tol))
+            .into_iter()
+            .map(|p| p.coords.cast::<f32>().to_homogeneous().into())
+            .collect_vec();
+        let n = tess.len();
+        let c0 = Oklaba::from(YELLOW);
+        let c1 = Oklaba::from(BLUE);
+        let pts = tess.into_iter().enumerate().map(|(i, p)| {
+            let t = (i as f32) / (n as f32);
+            let c = c0.mix(&c1, t);
+            (p, c)
+        });
+        gizmos.linestrip_gradient(pts);
+
+        c.spans()
+            .iter()
+            .flat_map(|c| c.dehomogenized_control_points())
+            .for_each(|p| {
+                let p: Vec3 = p.coords.cast::<f32>().to_homogeneous().into();
+                gizmos.sphere(p, 0.035, LIGHT_GREEN);
+            });
+    });
+
+    /*
+    let offset_vertex = offset_vertex.single().unwrap();
+    offset_vertex.0.iter().for_each(|c| {
+        let tess = c
+            .tessellate(Some(tol))
+            .into_iter()
+            .map(|p| p.coords.cast::<f32>().to_homogeneous().into())
+            .collect_vec();
+        gizmos.linestrip(tess, TOMATO);
+    });
+    */
+}

--- a/examples/fillet_curve.rs
+++ b/examples/fillet_curve.rs
@@ -151,7 +151,7 @@ fn setup(mut commands: Commands, settings: Res<Setting>) {
 
     let curve = NurbsCurve2D::polyline(&points, true);
     let option = FilletRadiusOption::new(settings.radius);
-    let fillet_curve = curve.fillet(option.clone()).unwrap();
+    let fillet_curve = curve.fillet(option).unwrap();
 
     commands.spawn((ProfileCurve(curve),));
     commands.spawn((FilletCurve(fillet_curve),));
@@ -169,7 +169,7 @@ fn setup(mut commands: Commands, settings: Res<Setting>) {
         true,
     );
     let option = FilletRadiusOption::new(settings.radius);
-    let fillet_curve = curve.fillet(option.clone()).unwrap();
+    let fillet_curve = curve.fillet(option).unwrap();
 
     commands.spawn((Profile3DCurve(curve),));
     commands.spawn((Fillet3DCurve(fillet_curve),));

--- a/examples/fillet_curve.rs
+++ b/examples/fillet_curve.rs
@@ -46,7 +46,7 @@ impl Default for Setting {
         Self {
             radius: 0.2,
             dimension: Dimension::default(),
-            use_parameter: true,
+            use_parameter: false,
             parameter: 0.0,
             control_points: true,
         }

--- a/src/fillet/fillet_nurbs_curve.rs
+++ b/src/fillet/fillet_nurbs_curve.rs
@@ -1,0 +1,64 @@
+use nalgebra::{allocator::Allocator, DefaultAllocator, DimName};
+
+use crate::{curve::NurbsCurve, fillet::Fillet, misc::FloatingPoint};
+
+#[derive(Debug, Clone, Copy)]
+pub struct FilletRadiusOption<T: FloatingPoint> {
+    radius: T,
+}
+
+impl<T: FloatingPoint> FilletRadiusOption<T> {
+    pub fn new(radius: T) -> Self {
+        Self { radius }
+    }
+
+    pub fn radius(&self) -> T {
+        self.radius
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct FilletRadiusParameterOption<T: FloatingPoint> {
+    radius: T,
+    parameter: T,
+}
+
+impl<T: FloatingPoint> FilletRadiusParameterOption<T> {
+    pub fn new(radius: T, parameter: T) -> Self {
+        Self { radius, parameter }
+    }
+
+    pub fn radius(&self) -> T {
+        self.radius
+    }
+
+    pub fn parameter(&self) -> T {
+        self.parameter
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct FilletDistanceOption<T: FloatingPoint> {
+    distance: T,
+}
+
+impl<T: FloatingPoint> FilletDistanceOption<T> {
+    pub fn new(distance: T) -> Self {
+        Self { distance }
+    }
+
+    pub fn distance(&self) -> T {
+        self.distance
+    }
+}
+
+impl<T: FloatingPoint, D: DimName> Fillet<FilletRadiusOption<T>> for NurbsCurve<T, D>
+where
+    DefaultAllocator: Allocator<D>,
+{
+    type Output = Self;
+
+    fn fillet(&self, option: FilletRadiusOption<T>) -> Self::Output {
+        self.clone()
+    }
+}

--- a/src/fillet/fillet_nurbs_curve.rs
+++ b/src/fillet/fillet_nurbs_curve.rs
@@ -1,6 +1,10 @@
-use nalgebra::{allocator::Allocator, DefaultAllocator, DimName};
+use itertools::Itertools;
+use nalgebra::{
+    allocator::Allocator, Const, DefaultAllocator, DimName, DimNameAdd, DimNameDiff, DimNameSub,
+    OPoint, OVector, Point2, Vector2, U1,
+};
 
-use crate::{curve::NurbsCurve, fillet::Fillet, misc::FloatingPoint};
+use crate::{curve::NurbsCurve, fillet::Fillet, misc::FloatingPoint, region::CompoundCurve};
 
 #[derive(Debug, Clone, Copy)]
 pub struct FilletRadiusOption<T: FloatingPoint> {
@@ -52,13 +56,248 @@ impl<T: FloatingPoint> FilletDistanceOption<T> {
     }
 }
 
-impl<T: FloatingPoint, D: DimName> Fillet<FilletRadiusOption<T>> for NurbsCurve<T, D>
+/// Segment of a curve
+#[derive(Debug, Clone)]
+struct Segment<T: FloatingPoint, D: DimName>
 where
     DefaultAllocator: Allocator<D>,
 {
-    type Output = Self;
+    start: OPoint<T, D>,
+    end: OPoint<T, D>,
+    tangent: OVector<T, D>,
+    length: T,
+}
 
-    fn fillet(&self, option: FilletRadiusOption<T>) -> Self::Output {
-        self.clone()
+impl<T: FloatingPoint, D: DimName> Segment<T, D>
+where
+    DefaultAllocator: Allocator<D>,
+{
+    fn new(start: OPoint<T, D>, end: OPoint<T, D>) -> Self {
+        let tangent = &end - &start;
+        let length = tangent.norm();
+        Self {
+            start,
+            end,
+            tangent: tangent.normalize(),
+            length,
+        }
     }
+
+    fn start(&self) -> &OPoint<T, D> {
+        &self.start
+    }
+
+    fn end(&self) -> &OPoint<T, D> {
+        &self.end
+    }
+
+    fn tangent(&self) -> &OVector<T, D> {
+        &self.tangent
+    }
+
+    fn length(&self) -> T {
+        self.length
+    }
+
+    /// Trim the segment by a given length
+    fn trim(&self, length: T) -> (Self, Self) {
+        let t = self.tangent() * length;
+        let end = self.start() + &t;
+        (
+            Self::new(self.start().clone(), end.clone()),
+            Self::new(end, self.end().clone()),
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+enum Span<T: FloatingPoint, D: DimName>
+where
+    DefaultAllocator: Allocator<D>,
+    D: DimNameSub<U1>,
+    DefaultAllocator: Allocator<DimNameDiff<D, U1>>,
+{
+    Segment(Segment<T, DimNameDiff<D, U1>>),
+    Fillet(NurbsCurve<T, D>),
+}
+
+impl<T: FloatingPoint, D: DimName> Fillet<FilletRadiusOption<T>> for NurbsCurve<T, D>
+where
+    D: DimNameSub<U1>,
+    DefaultAllocator: Allocator<D>,
+    DefaultAllocator: Allocator<DimNameDiff<D, U1>>,
+    <D as DimNameSub<U1>>::Output: DimNameAdd<U1>,
+    DefaultAllocator: Allocator<<<D as DimNameSub<U1>>::Output as DimNameAdd<U1>>::Output>,
+{
+    type Output = anyhow::Result<CompoundCurve<T, D>>;
+
+    /// Fillet the sharp corners of the curve with a given radius
+    fn fillet(&self, option: FilletRadiusOption<T>) -> Self::Output {
+        let radius = option.radius();
+        let degree = self.degree();
+
+        if degree >= 2 || radius <= T::zero() {
+            return Ok(self.clone().into());
+        }
+
+        let pts = self.dehomogenized_control_points();
+
+        let segments = pts
+            .windows(2)
+            .map(|w| {
+                let p0 = &w[0];
+                let p1 = &w[1];
+                Segment::new(p0.clone(), p1.clone())
+            })
+            .collect_vec();
+
+        let is_closed = self.is_closed();
+        let n = segments.len();
+        let m = if is_closed { n + 1 } else { n };
+
+        let half = T::from_f64(0.5).unwrap();
+
+        // calculate angle and fillet length for each segment
+        let angle_fillet_length = segments
+            .iter()
+            .cycle()
+            .take(m)
+            .collect_vec()
+            .windows(2)
+            .enumerate()
+            .map(|(_i, w)| {
+                let s0 = &w[0];
+                let s1 = &w[1];
+                let t0 = s0.tangent();
+                let t1 = s1.tangent();
+                let cos_angle = t0.dot(&t1);
+                let angle = cos_angle.acos();
+                if angle < T::from_f64(1e-4).unwrap() {
+                    return None;
+                }
+                let half_angle = angle / T::from_f64(2.0).unwrap();
+                let tan_half = half_angle.tan();
+                let fillet_length = radius * tan_half;
+
+                let l0 = s0.length() * half;
+                let l1 = s1.length() * half;
+                Some((angle, fillet_length.min(l0).min(l1)))
+            })
+            .collect_vec();
+
+        let l = angle_fillet_length.len();
+
+        let trimmed = segments
+            .iter()
+            .enumerate()
+            .map(|(i, current)| {
+                let prev_fillet = if i != 0 || is_closed {
+                    angle_fillet_length[(i + l - 1) % l]
+                } else {
+                    None
+                };
+
+                let next_fillet = if i != n - 1 || is_closed {
+                    angle_fillet_length[i % l]
+                } else {
+                    None
+                };
+
+                let start = match prev_fillet {
+                    Some((_, length)) => current.trim(length).0.end().clone(),
+                    None => current.start().clone(),
+                };
+
+                let end = match next_fillet {
+                    Some((_, length)) => current.trim(current.length() - length).1.start().clone(),
+                    None => current.end().clone(),
+                };
+                Segment::new(start, end)
+            })
+            .collect_vec();
+
+        let corners = trimmed
+            .iter()
+            .cycle()
+            .take(m)
+            .collect_vec()
+            .windows(2)
+            .zip(angle_fillet_length.iter())
+            .map(|(w, af)| {
+                let s0 = w[0];
+                let s1 = w[1];
+                let t0 = s0.tangent();
+                let t1 = s1.tangent();
+
+                match af {
+                    Some(_) => {
+                        let fillet_arc = create_fillet_arc(s0.end(), s1.start(), t0, t1, radius)?;
+                        Ok(Some(fillet_arc))
+                    }
+                    None => Ok(None),
+                }
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        let spans: Vec<Option<Span<T, D>>> = trimmed
+            .into_iter()
+            .map(|s| Some(Span::Segment(s)))
+            .interleave(corners.into_iter().map(|c| c.map(|c| Span::Fillet(c))))
+            .collect_vec();
+
+        let mut curves = vec![];
+        let mut polyline = vec![];
+        for s in spans {
+            match s {
+                Some(Span::Segment(s)) => {
+                    polyline.push(s.start().clone());
+                    polyline.push(s.end().clone());
+                }
+                Some(Span::Fillet(c)) => {
+                    polyline.dedup();
+                    curves.push(NurbsCurve::polyline(&polyline, false));
+                    curves.push(c);
+                    polyline.clear();
+                }
+                None => {}
+            }
+        }
+
+        if !polyline.is_empty() {
+            polyline.dedup();
+            curves.push(NurbsCurve::polyline(&polyline, false));
+        }
+
+        Ok(CompoundCurve::new_unchecked_aligned(curves))
+    }
+}
+
+/// Create a fillet arc curve
+fn create_fillet_arc<T: FloatingPoint, D: DimName>(
+    start: &OPoint<T, DimNameDiff<D, U1>>,
+    end: &OPoint<T, DimNameDiff<D, U1>>,
+    t0: &OVector<T, DimNameDiff<D, U1>>,
+    t1: &OVector<T, DimNameDiff<D, U1>>,
+    radius: T,
+) -> anyhow::Result<NurbsCurve<T, D>>
+where
+    D: DimNameSub<U1>,
+    DefaultAllocator: Allocator<D>,
+    DefaultAllocator: Allocator<DimNameDiff<D, U1>>,
+    <D as DimNameSub<U1>>::Output: DimNameAdd<U1>,
+    DefaultAllocator: Allocator<<<D as DimNameSub<U1>>::Output as DimNameAdd<U1>>::Output>,
+{
+    let center = start + t1 * radius;
+    let x_axis = -t1;
+    let y_axis = t0;
+    let arc_angle = t0.angle(&t1);
+
+    NurbsCurve::try_arc(
+        &center,
+        &x_axis,
+        &y_axis,
+        radius,
+        T::zero(),
+        arc_angle.abs(),
+    )
 }

--- a/src/fillet/fillet_nurbs_curve.rs
+++ b/src/fillet/fillet_nurbs_curve.rs
@@ -4,7 +4,7 @@ use nalgebra::{
     OVector, Rotation3, Unit, Vector3, U1,
 };
 
-use crate::{curve::NurbsCurve, fillet::Fillet, misc::FloatingPoint, region::CompoundCurve};
+use crate::{curve::NurbsCurve, fillet::{segment::Segment, Fillet}, misc::FloatingPoint, region::CompoundCurve};
 
 /// Fillet the sharp corners of the curve with a given radius
 #[derive(Debug, Clone, Copy)]
@@ -56,60 +56,6 @@ impl<T: FloatingPoint> FilletDistanceOption<T> {
 
     pub fn distance(&self) -> T {
         self.distance
-    }
-}
-
-/// Segment of a curve
-#[derive(Debug, Clone)]
-struct Segment<T: FloatingPoint, D: DimName>
-where
-    DefaultAllocator: Allocator<D>,
-{
-    start: OPoint<T, D>,
-    end: OPoint<T, D>,
-    tangent: OVector<T, D>,
-    length: T,
-}
-
-impl<T: FloatingPoint, D: DimName> Segment<T, D>
-where
-    DefaultAllocator: Allocator<D>,
-{
-    fn new(start: OPoint<T, D>, end: OPoint<T, D>) -> Self {
-        let tangent = &end - &start;
-        let length = tangent.norm();
-        Self {
-            start,
-            end,
-            tangent: tangent.normalize(),
-            length,
-        }
-    }
-
-    fn start(&self) -> &OPoint<T, D> {
-        &self.start
-    }
-
-    fn end(&self) -> &OPoint<T, D> {
-        &self.end
-    }
-
-    fn tangent(&self) -> &OVector<T, D> {
-        &self.tangent
-    }
-
-    fn length(&self) -> T {
-        self.length
-    }
-
-    /// Trim the segment by a given length
-    fn trim(&self, length: T) -> (Self, Self) {
-        let t = self.tangent() * length;
-        let end = self.start() + &t;
-        (
-            Self::new(self.start().clone(), end.clone()),
-            Self::new(end, self.end().clone()),
-        )
     }
 }
 

--- a/src/fillet/fillet_nurbs_curve.rs
+++ b/src/fillet/fillet_nurbs_curve.rs
@@ -1,11 +1,12 @@
 use itertools::Itertools;
 use nalgebra::{
-    allocator::Allocator, Const, DVector, DefaultAllocator, DimName, DimNameAdd, DimNameDiff,
-    DimNameSub, OPoint, OVector, Point2, Vector2, U1,
+    allocator::Allocator, DefaultAllocator, DimName, DimNameAdd, DimNameDiff, DimNameSub, OPoint,
+    OVector, Rotation3, Unit, Vector3, U1,
 };
 
 use crate::{curve::NurbsCurve, fillet::Fillet, misc::FloatingPoint, region::CompoundCurve};
 
+/// Fillet the sharp corners of the curve with a given radius
 #[derive(Debug, Clone, Copy)]
 pub struct FilletRadiusOption<T: FloatingPoint> {
     radius: T,
@@ -21,6 +22,7 @@ impl<T: FloatingPoint> FilletRadiusOption<T> {
     }
 }
 
+/// Fillet the sharp corners of the curve with a given radius and parameter
 #[derive(Debug, Clone, Copy)]
 pub struct FilletRadiusParameterOption<T: FloatingPoint> {
     radius: T,
@@ -41,6 +43,7 @@ impl<T: FloatingPoint> FilletRadiusParameterOption<T> {
     }
 }
 
+/// Fillet the sharp corners of the curve with a given distance
 #[derive(Debug, Clone, Copy)]
 pub struct FilletDistanceOption<T: FloatingPoint> {
     distance: T,
@@ -110,6 +113,7 @@ where
     }
 }
 
+/// Span of a fillet curve
 #[derive(Debug, Clone)]
 enum Span<T: FloatingPoint, D: DimName>
 where
@@ -132,6 +136,22 @@ where
     type Output = anyhow::Result<CompoundCurve<T, D>>;
 
     /// Fillet the sharp corners of the curve with a given radius
+    /// # Example
+    /// ```
+    /// use nalgebra::Point2;
+    /// use curvo::prelude::*;
+    ///
+    /// let square = vec![
+    ///     Point2::new(-1.0, -1.0),
+    ///     Point2::new(1.0, -1.0),
+    ///     Point2::new(1.0, 1.0),
+    ///     Point2::new(-1.0, 1.0),
+    ///     Point2::new(-1.0, -1.0),
+    /// ];
+    /// let curve = NurbsCurve2D::polyline(&square, false);
+    /// let fillet = curve.fillet(FilletRadiusOption::new(0.2)).unwrap();
+    /// assert_eq!(fillet.spans().len(), 8);
+    /// ```
     fn fillet(&self, option: FilletRadiusOption<T>) -> Self::Output {
         let radius = option.radius();
         let degree = self.degree();
@@ -156,6 +176,7 @@ where
         let m = if is_closed { n + 1 } else { n };
 
         let half = T::from_f64(0.5).unwrap();
+        let eps = T::from_f64(1e-6).unwrap();
 
         // calculate angle and fillet length for each segment
         let angle_fillet_length = segments
@@ -164,29 +185,27 @@ where
             .take(m)
             .collect_vec()
             .windows(2)
-            .enumerate()
-            .map(|(_i, w)| {
+            .map(|w| {
                 let s0 = &w[0];
                 let s1 = &w[1];
                 let t0 = s0.tangent();
                 let t1 = s1.tangent();
-                let cos_angle = t0.dot(&t1).clamp(-T::one(), T::one());
+                let cos_angle = t0.dot(t1).clamp(-T::one(), T::one());
                 let angle = cos_angle.acos();
                 if angle < T::from_f64(1e-4).unwrap() {
                     return None;
                 }
                 let half_angle = angle * half;
 
-                // let sin_half = half_angle.sin();
-                // let cos_half = half_angle.cos();
-                // let fillet_length = radius * cos_half / sin_half;
-
                 let tan_half = half_angle.tan();
                 let fillet_length = radius * tan_half;
 
-                let l0 = s0.length() * half;
-                let l1 = s1.length() * half;
-                Some((angle, fillet_length.min(l0).min(l1)))
+                let min = s0.length().min(s1.length());
+                let l = min * half - eps;
+
+                let actural_fillet_length = fillet_length.min(l);
+                let actural_radius = actural_fillet_length / tan_half;
+                Some((angle, actural_fillet_length, actural_radius))
             })
             .collect_vec();
 
@@ -209,12 +228,14 @@ where
                 };
 
                 let start = match prev_fillet {
-                    Some((_, length)) => current.trim(length).0.end().clone(),
+                    Some((_, length, _)) => current.trim(length).0.end().clone(),
                     None => current.start().clone(),
                 };
 
                 let end = match next_fillet {
-                    Some((_, length)) => current.trim(current.length() - length).1.start().clone(),
+                    Some((_, length, _)) => {
+                        current.trim(current.length() - length).1.start().clone()
+                    }
                     None => current.end().clone(),
                 };
                 (current, Segment::new(start, end))
@@ -235,7 +256,7 @@ where
                 let t1 = s1.1.tangent();
 
                 match af {
-                    Some((angle, _)) => {
+                    Some((angle, _, radius)) => {
                         let corner = s0.0.end();
                         let fillet_arc = create_fillet_arc(
                             s0.1.end(),
@@ -244,7 +265,7 @@ where
                             t0,
                             t1,
                             T::pi() - *angle,
-                            radius,
+                            *radius,
                         )?;
                         Ok(Some(fillet_arc))
                     }
@@ -290,7 +311,7 @@ where
 fn create_fillet_arc<T: FloatingPoint, D: DimName>(
     start: &OPoint<T, DimNameDiff<D, U1>>,
     corner: &OPoint<T, DimNameDiff<D, U1>>,
-    end: &OPoint<T, DimNameDiff<D, U1>>,
+    _end: &OPoint<T, DimNameDiff<D, U1>>,
     t0: &OVector<T, DimNameDiff<D, U1>>,
     t1: &OVector<T, DimNameDiff<D, U1>>,
     angle: T,
@@ -303,22 +324,29 @@ where
     <D as DimNameSub<U1>>::Output: DimNameAdd<U1>,
     DefaultAllocator: Allocator<<<D as DimNameSub<U1>>::Output as DimNameAdd<U1>>::Output>,
 {
+    anyhow::ensure!(
+        D::dim() - 1 <= 3,
+        "Curve dimension must be less than or equal to 3, but got {}",
+        D::dim() - 1
+    );
+
     let theta = angle / T::from_f64(2.0).unwrap();
     let r = radius / theta.sin();
 
-    // let bisector = ((t1 + t0) / T::from_f64(2.0).unwrap() - t0).normalize();
     let bisector = (t1 - t0).normalize();
     let center = corner + bisector * r;
 
     let x_axis = (start - &center).normalize();
-    let y_axis = if D::dim() > 3 {
-        let n = t0.cross(t1);
-        n
-    } else {
-        let x = x_axis.as_slice();
-        OVector::<T, DimNameDiff<D, U1>>::from_vec(vec![x[1], -x[0]])
-    };
-    let y_axis = if y_axis.dot(&t0) < T::zero() {
+
+    let t0_3d = to_3d_vector(t0).normalize();
+    let t1_3d = to_3d_vector(t1).normalize();
+    let rot = rotate_around_axis(&t0_3d, &t1_3d, T::frac_pi_2());
+
+    let dx = to_3d_vector(&x_axis);
+    let dy = rot * dx;
+    let y_axis = OVector::<T, DimNameDiff<D, U1>>::from_vec(dy.as_slice().to_vec());
+
+    let y_axis = if y_axis.dot(t0) < T::zero() {
         -y_axis
     } else {
         y_axis
@@ -327,5 +355,76 @@ where
     // debug
     // return Ok(NurbsCurve::polyline( &vec![start.clone(), center.clone(), end.clone()], false,));
     // return NurbsCurve::try_circle(&center, &x_axis, &y_axis, radius);
-    NurbsCurve::try_arc(&center, &x_axis, &y_axis, radius, T::zero(), T::pi() - angle.abs())
+    NurbsCurve::try_arc(
+        &center,
+        &x_axis,
+        &y_axis,
+        radius,
+        T::zero(),
+        T::pi() - angle.abs(),
+    )
+}
+
+/// Convert a 2d dimension vector to 3D vector
+/// if D is 2, return the vector with z = 0
+/// if D is 3, return the vector itself
+fn to_3d_vector<T: FloatingPoint, D: DimName>(v: &OVector<T, D>) -> Vector3<T>
+where
+    DefaultAllocator: Allocator<D>,
+{
+    if D::dim() == 2 {
+        Vector3::new(v[0], v[1], T::zero())
+    } else {
+        let v = v.as_slice().to_vec();
+        Vector3::new(v[0], v[1], v[2])
+    }
+}
+
+/// Rotate a vector around an axis
+fn rotate_around_axis<T: FloatingPoint>(
+    dx: &Vector3<T>,
+    dy: &Vector3<T>,
+    theta: T,
+) -> Rotation3<T> {
+    let n = dx.cross(dy).normalize();
+    let axis = Unit::new_normalize(n);
+    Rotation3::from_axis_angle(&axis, theta)
+}
+
+#[cfg(test)]
+mod tests {
+    use approx::assert_relative_eq;
+    use nalgebra::Point2;
+
+    use crate::curve::NurbsCurve2D;
+
+    use super::*;
+
+    /// Test if the fillet curve is connected
+    #[test]
+    fn test_fillet_curve_connectivity() {
+        let points = vec![
+            Point2::new(-0.5, 2.),
+            Point2::new(0.5, 2.),
+            Point2::new(0.5, 1.),
+            Point2::new(1.5, 1.),
+            Point2::new(1.5, -1.),
+            Point2::new(-1.5, -1.),
+            Point2::new(-1.5, 1.),
+            Point2::new(-0.5, 1.),
+            Point2::new(-0.5, 2.),
+        ]
+        .into_iter()
+        .collect_vec();
+        let curve = NurbsCurve2D::polyline(&points, false);
+        let fillet = curve.fillet(FilletRadiusOption::new(0.2)).unwrap();
+        let spans = fillet.spans();
+        spans.windows(2).for_each(|w| {
+            let s0 = &w[0];
+            let s1 = &w[1];
+            let end = s0.point_at(s0.knots_domain().1);
+            let start = s1.point_at(s1.knots_domain().0);
+            assert_relative_eq!(end, start, epsilon = 1e-6);
+        });
+    }
 }

--- a/src/fillet/mod.rs
+++ b/src/fillet/mod.rs
@@ -1,5 +1,8 @@
 pub mod fillet_nurbs_curve;
+mod segment;
 pub use fillet_nurbs_curve::*;
+
+use segment::*;
 
 /// Trait for filleting a geometry
 /// O is the option type for the fillet

--- a/src/fillet/mod.rs
+++ b/src/fillet/mod.rs
@@ -1,0 +1,9 @@
+pub mod fillet_nurbs_curve;
+pub use fillet_nurbs_curve::*;
+
+/// Trait for filleting a geometry
+/// O is the option type for the fillet
+pub trait Fillet<O> {
+    type Output;
+    fn fillet(&self, option: O) -> Self::Output;
+}

--- a/src/fillet/mod.rs
+++ b/src/fillet/mod.rs
@@ -2,8 +2,6 @@ pub mod fillet_nurbs_curve;
 mod segment;
 pub use fillet_nurbs_curve::*;
 
-use segment::*;
-
 /// Trait for filleting a geometry
 /// O is the option type for the fillet
 pub trait Fillet<O> {

--- a/src/fillet/segment.rs
+++ b/src/fillet/segment.rs
@@ -1,0 +1,57 @@
+use nalgebra::{allocator::Allocator, DefaultAllocator, DimName, OPoint, OVector};
+
+use crate::misc::FloatingPoint;
+
+/// Segment of a curve
+#[derive(Debug, Clone)]
+pub struct Segment<T: FloatingPoint, D: DimName>
+where
+    DefaultAllocator: Allocator<D>,
+{
+    start: OPoint<T, D>,
+    end: OPoint<T, D>,
+    tangent: OVector<T, D>,
+    length: T,
+}
+
+impl<T: FloatingPoint, D: DimName> Segment<T, D>
+where
+    DefaultAllocator: Allocator<D>,
+{
+    pub fn new(start: OPoint<T, D>, end: OPoint<T, D>) -> Self {
+        let tangent = &end - &start;
+        let length = tangent.norm();
+        Self {
+            start,
+            end,
+            tangent: tangent.normalize(),
+            length,
+        }
+    }
+
+    pub fn start(&self) -> &OPoint<T, D> {
+        &self.start
+    }
+
+    pub fn end(&self) -> &OPoint<T, D> {
+        &self.end
+    }
+
+    pub fn tangent(&self) -> &OVector<T, D> {
+        &self.tangent
+    }
+
+    pub fn length(&self) -> T {
+        self.length
+    }
+
+    /// Trim the segment by a given length
+    pub fn trim(&self, length: T) -> (Self, Self) {
+        let t = self.tangent() * length;
+        let end = self.start() + &t;
+        (
+            Self::new(self.start().clone(), end.clone()),
+            Self::new(end, self.end().clone()),
+        )
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ mod closest_parameter;
 mod contains;
 mod curve;
 mod dimension;
+mod fillet;
 mod intersects;
 mod knot;
 mod misc;
@@ -79,6 +80,7 @@ pub mod prelude {
     pub use crate::contains::*;
     pub use crate::curve::*;
     pub use crate::dimension::*;
+    pub use crate::fillet::*;
     pub use crate::intersects::*;
     pub use crate::knot::*;
     pub use crate::misc::*;

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -27,6 +27,7 @@ impl Default for CurveOffsetCornerType {
     }
 }
 
+/// Trait for offsetting a geometry
 pub trait Offset<'a, T> {
     type Output;
     type Option;


### PR DESCRIPTION
This pull request introduces several enhancements and additions to the `curvo` library, focusing on new functionality for fillet curves, updates to examples, and improvements to the library's modular structure. Key changes include the addition of a new example for fillet curves, updates to the library's traits and modules to support filleting operations, and new visual assets in the `README.md`.

### Enhancements to Examples and Documentation:
* Added a new example `fillet_curve` in `Cargo.toml` and implemented the corresponding `examples/fillet_curve.rs` file, showcasing the creation and manipulation of fillet curves in both 2D and 3D using Bevy plugins. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R195-R199) [[2]](diffhunk://#diff-006dd4d1a43e7aa6c6add66c0167a8364dfee77f1e049ef581568b08819613c5R1-R396)
* Updated the `README.md` to include a new visual asset illustrating fillet curves.

### Fillet Curve Functionality:
* Introduced a `Fillet` trait in `src/fillet/mod.rs` for filleting geometries, along with a new `Segment` struct in `src/fillet/segment.rs` to represent curve segments with attributes like start, end, tangent, and length. [[1]](diffhunk://#diff-f001eb60d142eedd9326e91bf9b01ef4546cbad75692cce300235fc9686501f5R1-R10) [[2]](diffhunk://#diff-e2103002216ac4a10beb1f8bb3dd4f8d9fb80411dd0a496661ef09f0e05ed851R1-R57)

### Library Modularization:
* Added the `fillet` module to the library's main structure (`src/lib.rs`) and included it in the `prelude` for easy access. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R64) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R83)

### Minor Updates:
* Documented the `Offset` trait in `src/offset/mod.rs` to clarify its purpose for offsetting geometries.

These changes collectively improve the library's functionality, usability, and documentation, making it easier for developers to work with advanced curve operations.