### PR TITLE
0.1.58

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4875,9 +4875,9 @@ dependencies = [
 
 [[package]]
 name = "spade"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ece03ff43cd2a9b57ebf776ea5e78bd30b3b4185a619f041079f4109f385034"
+checksum = "a14e31a007e9f85c32784b04f89e6e194bb252a4d41b4a8ccd9e77245d901c8c"
 dependencies = [
  "hashbrown 0.15.2",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2071,7 +2071,7 @@ checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 
 [[package]]
 name = "curvo"
-version = "0.1.57"
+version = "0.1.58"
 dependencies = [
  "anyhow",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curvo"
-version = "0.1.57"
+version = "0.1.58"
 authors = ["Masatatsu Nakamura <masatatsu.nakamura@gmail.com"]
 edition = "2021"
 keywords = ["nurbs", "modeling", "graphics", "3d"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rand_distr = { version = "0.5.1", default-features = false, optional = true }
 robust = { version = "1.2.0" }
 easer = { version = "0.3.0", optional = true }
 simba = { version = "0.9.0", default-features = false }
-spade = { version = "2.13.1" }
+spade = { version = "2.14.0" }
 gauss-quad = "0.2.3"
 geo = { version = "0.29.3" }
 bevy = { version = "0.16.1", optional = true }
@@ -42,8 +42,8 @@ approx = { version = "0.5", default-features = false }
 serde_json = "1.0.140"
 
 [features]
-# default = []
-default = ["bevy", "serde"] # for debugging example
+default = []
+# default = ["bevy", "serde"] # for debugging example
 bevy = [
   "dep:easer",
   "dep:rand_distr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ approx = { version = "0.5", default-features = false }
 serde_json = "1.0.140"
 
 [features]
-default = []
-# default = ["bevy", "serde"] # for debugging example
+# default = []
+default = ["bevy", "serde"] # for debugging example
 bevy = [
   "dep:easer",
   "dep:rand_distr",
@@ -196,4 +196,9 @@ required-features = ["bevy"]
 [[example]]
 name = "fillet_curve"
 path = "examples/fillet_curve.rs"
+required-features = ["bevy"]
+
+[[example]]
+name = "fillet_compound_curve"
+path = "examples/fillet_compound_curve.rs"
 required-features = ["bevy"]

--- a/examples/fillet_compound_curve.rs
+++ b/examples/fillet_compound_curve.rs
@@ -9,7 +9,7 @@ use bevy_infinite_grid::InfiniteGridPlugin;
 use bevy_panorbit_camera::{PanOrbitCamera, PanOrbitCameraPlugin};
 use bevy_points::plugin::PointsPlugin;
 use itertools::Itertools;
-use nalgebra::{Point2, Point3};
+use nalgebra::Point2;
 
 use curvo::prelude::*;
 
@@ -20,7 +20,6 @@ mod misc;
 use boolean::*;
 use materials::*;
 use misc::*;
-use rand::Rng;
 
 #[derive(Resource, Debug)]
 struct Setting {
@@ -83,12 +82,14 @@ impl Plugin for AppPlugin {
     }
 }
 
+#[allow(clippy::useless_vec)]
 fn setup(mut commands: Commands, settings: Res<Setting>) {
     let curve = match compound_rounded_t_shape() {
         boolean::CurveVariant::Compound(c) => c.inverse(),
         _ => todo!(),
     };
 
+    // convex shape
     let points = [
         Point2::new(-0.5, 2.),
         Point2::new(0.5, 2.),
@@ -104,7 +105,7 @@ fn setup(mut commands: Commands, settings: Res<Setting>) {
         .windows(2)
         .map(|w| NurbsCurve2D::polyline(w, true))
         .collect_vec();
-    let curve = CompoundCurve::try_new(spans).unwrap();
+    let _curve = CompoundCurve::try_new(spans).unwrap();
 
     if settings.use_parameter {
         let option = FilletRadiusParameterOption::new(settings.radius, settings.parameter);
@@ -178,7 +179,7 @@ fn update_ui(
                         changed |= ui
                             .add(
                                 egui::DragValue::new(&mut settings.parameter)
-                                    .speed(1e-2)
+                                    .speed(1e-1)
                                     .range(domain.0..=domain.1),
                             )
                             .changed();

--- a/examples/fillet_compound_curve.rs
+++ b/examples/fillet_compound_curve.rs
@@ -108,8 +108,8 @@ fn setup(mut commands: Commands, settings: Res<Setting>) {
 
     if settings.use_parameter {
         let option = FilletRadiusParameterOption::new(settings.radius, settings.parameter);
-        // let fillet_curve = curve.fillet(option).unwrap();
-        // commands.spawn((FilletCurve(fillet_curve),));
+        let fillet_curve = curve.fillet(option).unwrap();
+        commands.spawn((FilletCurve(fillet_curve),));
     } else {
         let option = FilletRadiusOption::new(settings.radius);
         let fillet_curve = curve.fillet(option).unwrap();
@@ -148,7 +148,7 @@ fn update_ui(
 
     let mut changed = false;
 
-    egui::Window::new("fillet curve")
+    egui::Window::new("fillet compound curve")
         .collapsible(false)
         .drag_to_scroll(false)
         .default_width(420.)
@@ -199,12 +199,10 @@ fn update_ui(
 
         if settings.use_parameter {
             let option = FilletRadiusParameterOption::new(settings.radius, settings.parameter);
-            /*
             let res = profile.0.fillet(option);
             if let Ok(res) = res {
                 fillet_curve.0 = res;
             }
-            */
         } else {
             let option = FilletRadiusOption::new(settings.radius);
             let res = profile.0.fillet(option);

--- a/examples/fillet_compound_curve.rs
+++ b/examples/fillet_compound_curve.rs
@@ -1,0 +1,262 @@
+use bevy::{
+    color::palettes::css::{BLUE, LIGHT_GREEN, WHITE, YELLOW},
+    prelude::*,
+    render::camera::ScalingMode,
+};
+use bevy_egui::{egui, EguiContextPass, EguiContexts, EguiPlugin};
+use bevy_infinite_grid::InfiniteGridPlugin;
+
+use bevy_panorbit_camera::{PanOrbitCamera, PanOrbitCameraPlugin};
+use bevy_points::plugin::PointsPlugin;
+use itertools::Itertools;
+use nalgebra::{Point2, Point3};
+
+use curvo::prelude::*;
+
+mod boolean;
+mod materials;
+mod misc;
+
+use boolean::*;
+use materials::*;
+use misc::*;
+use rand::Rng;
+
+#[derive(Resource, Debug)]
+struct Setting {
+    pub radius: f64,
+    pub use_parameter: bool,
+    pub parameter: f64,
+    pub control_points: bool,
+}
+
+impl Default for Setting {
+    fn default() -> Self {
+        Self {
+            radius: 0.2,
+            use_parameter: false,
+            parameter: 0.0,
+            control_points: true,
+        }
+    }
+}
+
+#[derive(Component)]
+struct ProfileCurve(pub CompoundCurve2D<f64>);
+
+#[derive(Component)]
+struct FilletCurve(pub CompoundCurve2D<f64>);
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            primary_window: Some(Window {
+                resolution: (640., 480.).into(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }))
+        .add_plugins(LineMaterialPlugin)
+        .add_plugins(InfiniteGridPlugin)
+        .add_plugins(PanOrbitCameraPlugin)
+        .add_plugins(PointsPlugin)
+        .add_plugins(EguiPlugin {
+            enable_multipass_for_primary_context: true,
+        })
+        .add_plugins(AppPlugin)
+        .run();
+}
+struct AppPlugin;
+
+impl Plugin for AppPlugin {
+    fn build(&self, app: &mut bevy::prelude::App) {
+        app.insert_resource(Setting::default())
+            .add_systems(Startup, setup)
+            .add_systems(
+                PreUpdate,
+                (absorb_egui_inputs,)
+                    .after(bevy_egui::input::write_egui_input_system)
+                    .before(bevy_egui::begin_pass_system),
+            )
+            .add_systems(EguiContextPass, update_ui)
+            .add_systems(Update, gizmos_curve);
+    }
+}
+
+fn setup(mut commands: Commands, settings: Res<Setting>) {
+    let curve = match compound_rounded_t_shape() {
+        boolean::CurveVariant::Compound(c) => c.inverse(),
+        _ => todo!(),
+    };
+
+    let points = [
+        Point2::new(-0.5, 2.),
+        Point2::new(0.5, 2.),
+        Point2::new(0.5, 1.),
+        Point2::new(1.5, 1.),
+        Point2::new(1.5, -1.),
+        Point2::new(-1.5, -1.),
+        Point2::new(-1.5, 1.),
+        Point2::new(-0.5, 1.),
+        Point2::new(-0.5, 2.),
+    ];
+    let spans = points
+        .windows(2)
+        .map(|w| NurbsCurve2D::polyline(w, true))
+        .collect_vec();
+    let curve = CompoundCurve::try_new(spans).unwrap();
+
+    if settings.use_parameter {
+        let option = FilletRadiusParameterOption::new(settings.radius, settings.parameter);
+        // let fillet_curve = curve.fillet(option).unwrap();
+        // commands.spawn((FilletCurve(fillet_curve),));
+    } else {
+        let option = FilletRadiusOption::new(settings.radius);
+        let fillet_curve = curve.fillet(option).unwrap();
+        commands.spawn((FilletCurve(fillet_curve),));
+    }
+
+    commands.spawn((ProfileCurve(curve),));
+
+    let scale = 5.;
+    commands.spawn((
+        Projection::Orthographic(OrthographicProjection {
+            scale,
+            near: 1e-1,
+            far: 1e4,
+            scaling_mode: ScalingMode::FixedVertical {
+                viewport_height: 2.,
+            },
+            ..OrthographicProjection::default_3d()
+        }),
+        Transform::from_translation(Vec3::new(0., 0., 3.)).looking_at(Vec3::ZERO, Vec3::Y),
+        PanOrbitCamera {
+            // orbit_sensitivity: 0.0,
+            ..Default::default()
+        },
+    ));
+}
+
+fn update_ui(
+    mut contexts: EguiContexts,
+    mut settings: ResMut<Setting>,
+    profile: Query<&ProfileCurve>,
+    mut fillet_curve: Query<&mut FilletCurve>,
+) {
+    let profile = profile.single().unwrap();
+    let domain = profile.0.knots_domain();
+
+    let mut changed = false;
+
+    egui::Window::new("fillet curve")
+        .collapsible(false)
+        .drag_to_scroll(false)
+        .default_width(420.)
+        .min_width(420.)
+        .max_width(420.)
+        .show(contexts.ctx_mut(), |ui| {
+            ui.heading("radius");
+            ui.group(|g| {
+                g.horizontal(|ui| {
+                    changed |= ui
+                        .add(
+                            egui::DragValue::new(&mut settings.radius)
+                                .speed(1e-2)
+                                .range(0.0..=5.0),
+                        )
+                        .changed();
+                });
+            });
+
+            ui.heading("parameter");
+            ui.group(|g| {
+                g.horizontal(|ui| {
+                    changed |= ui
+                        .checkbox(&mut settings.use_parameter, "activate")
+                        .changed();
+                    if settings.use_parameter {
+                        changed |= ui
+                            .add(
+                                egui::DragValue::new(&mut settings.parameter)
+                                    .speed(1e-2)
+                                    .range(domain.0..=domain.1),
+                            )
+                            .changed();
+                    }
+                });
+            });
+
+            ui.heading("control points");
+            ui.group(|g| {
+                g.horizontal(|ui| {
+                    ui.checkbox(&mut settings.control_points, "show");
+                });
+            });
+        });
+
+    if changed {
+        let mut fillet_curve = fillet_curve.single_mut().unwrap();
+
+        if settings.use_parameter {
+            let option = FilletRadiusParameterOption::new(settings.radius, settings.parameter);
+            /*
+            let res = profile.0.fillet(option);
+            if let Ok(res) = res {
+                fillet_curve.0 = res;
+            }
+            */
+        } else {
+            let option = FilletRadiusOption::new(settings.radius);
+            let res = profile.0.fillet(option);
+            if let Ok(res) = res {
+                fillet_curve.0 = res;
+            }
+        }
+    }
+}
+
+fn gizmos_curve(
+    profile: Query<&ProfileCurve>,
+    fillet_curve: Query<&FilletCurve>,
+    settings: Res<Setting>,
+    mut gizmos: Gizmos,
+) {
+    let tol = 1e-7 * 0.5;
+
+    let profile = profile.single().unwrap();
+
+    if !settings.use_parameter {
+        let tess = profile
+            .0
+            .tessellate(Some(tol))
+            .into_iter()
+            .map(|p| p.coords.cast::<f32>().to_homogeneous().into())
+            .collect_vec();
+        gizmos.linestrip(tess, WHITE.with_alpha(0.25));
+    }
+
+    let fillet_curve = fillet_curve.single().unwrap();
+    fillet_curve.0.spans().iter().for_each(|c| {
+        let tess: Vec<Vec3> = c
+            .tessellate(Some(tol))
+            .into_iter()
+            .map(|p| p.coords.cast::<f32>().to_homogeneous().into())
+            .collect_vec();
+        let n = tess.len();
+        let c0 = Oklaba::from(YELLOW);
+        let c1 = Oklaba::from(BLUE);
+        let pts = tess.into_iter().enumerate().map(|(i, p)| {
+            let t = (i as f32) / (n as f32);
+            let c = c0.mix(&c1, t);
+            (p, c)
+        });
+        gizmos.linestrip_gradient(pts);
+
+        if settings.control_points {
+            c.dehomogenized_control_points().iter().for_each(|p| {
+                let p: Vec3 = p.coords.cast::<f32>().to_homogeneous().into();
+                gizmos.sphere(p, 0.025, LIGHT_GREEN);
+            });
+        }
+    });
+}

--- a/examples/fillet_curve.rs
+++ b/examples/fillet_curve.rs
@@ -104,6 +104,7 @@ impl Plugin for AppPlugin {
     }
 }
 
+#[allow(clippy::useless_vec)]
 fn setup(mut commands: Commands, settings: Res<Setting>) {
     // s-shape
     let _points = [
@@ -266,7 +267,7 @@ fn update_ui(
                         changed |= ui
                             .add(
                                 egui::DragValue::new(&mut settings.parameter)
-                                    .speed(1e-2)
+                                    .speed(1e-1)
                                     .range(domain.0..=domain.1),
                             )
                             .changed();

--- a/src/fillet/curve_fillet_option.rs
+++ b/src/fillet/curve_fillet_option.rs
@@ -1,0 +1,64 @@
+use crate::misc::FloatingPoint;
+
+/// Fillet the sharp corners of the curve with a given radius
+#[derive(Debug, Clone, Copy)]
+pub struct FilletRadiusOption<T: FloatingPoint> {
+    radius: T,
+}
+
+impl<T: FloatingPoint> FilletRadiusOption<T> {
+    pub fn new(radius: T) -> Self {
+        Self { radius }
+    }
+
+    pub fn radius(&self) -> T {
+        self.radius
+    }
+}
+
+/// Only fillet the sharp corner at the specified parameter position with a given radius
+#[derive(Debug, Clone, Copy)]
+pub struct FilletRadiusParameterOption<T: FloatingPoint> {
+    radius: T,
+    parameter: T,
+}
+
+impl<T: FloatingPoint> FilletRadiusParameterOption<T> {
+    pub fn new(radius: T, parameter: T) -> Self {
+        Self { radius, parameter }
+    }
+
+    pub fn radius(&self) -> T {
+        self.radius
+    }
+
+    pub fn parameter(&self) -> T {
+        self.parameter
+    }
+
+    pub fn with_parameter(&mut self, parameter: T) -> &mut Self {
+        self.parameter = parameter;
+        self
+    }
+
+    pub fn with_radius(&mut self, radius: T) -> &mut Self {
+        self.radius = radius;
+        self
+    }
+}
+
+/// Fillet the sharp corners of the curve with a given distance
+#[derive(Debug, Clone, Copy)]
+pub struct FilletDistanceOption<T: FloatingPoint> {
+    distance: T,
+}
+
+impl<T: FloatingPoint> FilletDistanceOption<T> {
+    pub fn new(distance: T) -> Self {
+        Self { distance }
+    }
+
+    pub fn distance(&self) -> T {
+        self.distance
+    }
+}

--- a/src/fillet/fillet_compound_curve.rs
+++ b/src/fillet/fillet_compound_curve.rs
@@ -7,7 +7,9 @@ use crate::{
     curve::NurbsCurve,
     fillet::{
         helper::{
-            calculate_fillet_length, create_fillet_corner_between_trimmed_segments, decompose_into_segments, trim_segment_by_fillet_length, CompoundSegment, FilletLength, TrimmedSegment
+            calculate_fillet_length, create_fillet_corner_between_trimmed_segments,
+            decompose_into_segments, trim_segment_by_fillet_length, try_connect_compound_segments,
+            CompoundSegment, FilletLength, TrimmedSegment,
         },
         segment::Segment,
         Fillet, FilletRadiusOption,
@@ -151,28 +153,5 @@ where
         )
         .collect_vec();
 
-    let mut curves = vec![];
-    let mut polyline = vec![];
-    for s in spans {
-        match s {
-            Some(CompoundSegment::Segment(s)) => {
-                polyline.push(s.start().clone());
-                polyline.push(s.end().clone());
-            }
-            Some(CompoundSegment::Curve(c)) => {
-                polyline.dedup();
-                curves.push(NurbsCurve::polyline(&polyline, false));
-                curves.push(c);
-                polyline.clear();
-            }
-            None => {}
-        }
-    }
-
-    if !polyline.is_empty() {
-        polyline.dedup();
-        curves.push(NurbsCurve::polyline(&polyline, false));
-    }
-
-    Ok(CompoundCurve::new_unchecked_aligned(curves))
+    try_connect_compound_segments(spans)
 }

--- a/src/fillet/fillet_compound_curve.rs
+++ b/src/fillet/fillet_compound_curve.rs
@@ -32,6 +32,29 @@ where
     type Output = anyhow::Result<CompoundCurve<T, D>>;
 
     /// Fillet the sharp corners of the curve with a given radius
+    /// # Example
+    /// ```
+    /// use nalgebra::Point2;
+    /// use curvo::prelude::*;
+    ///
+    /// let points = [
+    ///     Point2::new(-1.0, -1.0),
+    ///     Point2::new(1.0, -1.0),
+    ///     Point2::new(1.0, 1.0),
+    ///     Point2::new(-1.0, 1.0),
+    ///     Point2::new(-1.0, -1.0),
+    /// ];
+    /// let spans = points.windows(2).map(|w| NurbsCurve2D::polyline(w, false)).collect();
+    /// let curve = CompoundCurve2D::try_new(spans).unwrap();
+    /// let fillet = curve.fillet(FilletRadiusOption::new(0.2)).unwrap();
+    /// assert_eq!(fillet.spans().len(), 8);
+    ///
+    /// let domain = fillet.knots_domain();
+    /// let pt = fillet.point_at(domain.0);
+    /// assert_eq!(pt, Point2::new(-0.8, -1.0));
+    /// let pt = fillet.point_at(domain.1);
+    /// assert_eq!(pt, Point2::new(-0.8, -1.0));
+    /// ```
     fn fillet(&self, option: FilletRadiusOption<T>) -> Self::Output {
         let radius = option.radius();
         anyhow::ensure!(
@@ -82,6 +105,23 @@ where
     type Output = anyhow::Result<CompoundCurve<T, D>>;
 
     /// Only fillet the sharp corner at the specified parameter position with a given radius
+    /// # Example
+    /// ```
+    /// use nalgebra::Point2;
+    /// use curvo::prelude::*;
+    ///
+    /// let points = [
+    ///     Point2::new(-1.0, -1.0),
+    ///     Point2::new(1.0, -1.0),
+    ///     Point2::new(1.0, 1.0),
+    ///     Point2::new(-1.0, 1.0),
+    ///     Point2::new(-1.0, -1.0),
+    /// ];
+    /// let spans = points.windows(2).map(|w| NurbsCurve2D::polyline(w, false)).collect();
+    /// let curve = CompoundCurve2D::try_new(spans).unwrap();
+    /// let fillet = curve.fillet(FilletRadiusParameterOption::new(0.2, 0.5)).unwrap();
+    /// assert_eq!(fillet.spans().len(), 3);
+    /// ```
     fn fillet(&self, option: FilletRadiusParameterOption<T>) -> Self::Output {
         let radius = option.radius();
         anyhow::ensure!(

--- a/src/fillet/fillet_compound_curve.rs
+++ b/src/fillet/fillet_compound_curve.rs
@@ -1,12 +1,10 @@
 use itertools::Itertools;
 use nalgebra::{
-    allocator::Allocator, DefaultAllocator, DimName, DimNameAdd, DimNameDiff, DimNameSub, OPoint,
-    OVector, Rotation3, Unit, Vector3, U1,
+    allocator::Allocator, DefaultAllocator, DimName, DimNameAdd, DimNameDiff, DimNameSub, U1,
 };
 
 use crate::{
-    curve::NurbsCurve,
-    fillet::{segment::Segment, Fillet, FilletRadiusOption, FilletRadiusParameterOption},
+    fillet::{Fillet, FilletRadiusOption},
     misc::FloatingPoint,
     region::CompoundCurve,
 };
@@ -31,8 +29,22 @@ where
             .map(|span| span.fillet(FilletRadiusOption::new(radius)))
             .collect::<anyhow::Result<Vec<_>>>()?;
 
-        let is_closed = self.is_closed(None);
+        // flatten the spans
+        let spans = spans.into_iter().flat_map(|c| c.into_spans()).collect_vec();
 
-        todo!()
+        let is_closed = self.is_closed(None);
+        if is_closed {
+            let last = spans
+                .last()
+                .ok_or(anyhow::anyhow!("Closed curve must have at least one span"))?;
+            let head = spans
+                .first()
+                .ok_or(anyhow::anyhow!("Closed curve must have at least one span"))?;
+            if last.degree() == 1 && last.degree() == head.degree() {
+                // create fillet arc
+            }
+        }
+
+        Ok(CompoundCurve::new_unchecked_aligned(spans))
     }
 }

--- a/src/fillet/fillet_compound_curve.rs
+++ b/src/fillet/fillet_compound_curve.rs
@@ -12,7 +12,7 @@ use crate::{
             CompoundSegment, FilletLength, TrimmedSegment,
         },
         segment::Segment,
-        Fillet, FilletRadiusOption,
+        Fillet, FilletRadiusOption, FilletRadiusParameterOption,
     },
     misc::FloatingPoint,
     region::CompoundCurve,
@@ -77,6 +77,22 @@ where
             .collect_vec();
 
         fillet_compound_curve(segments, angle_fillet_length, is_closed)
+    }
+}
+
+impl<T: FloatingPoint, D: DimName> Fillet<FilletRadiusParameterOption<T>> for CompoundCurve<T, D>
+where
+    D: DimNameSub<U1>,
+    DefaultAllocator: Allocator<D>,
+    DefaultAllocator: Allocator<DimNameDiff<D, U1>>,
+    <D as DimNameSub<U1>>::Output: DimNameAdd<U1>,
+    DefaultAllocator: Allocator<<<D as DimNameSub<U1>>::Output as DimNameAdd<U1>>::Output>,
+{
+    type Output = anyhow::Result<CompoundCurve<T, D>>;
+
+    /// Only fillet the sharp corner at the specified parameter position with a given radius
+    fn fillet(&self, option: FilletRadiusParameterOption<T>) -> Self::Output {
+        todo!()
     }
 }
 

--- a/src/fillet/fillet_compound_curve.rs
+++ b/src/fillet/fillet_compound_curve.rs
@@ -4,10 +4,20 @@ use nalgebra::{
 };
 
 use crate::{
-    fillet::{Fillet, FilletRadiusOption},
+    curve::NurbsCurve,
+    fillet::{
+        helper::{
+            calculate_fillet_length, create_fillet_corner_between_trimmed_segments, decompose_into_segments, trim_segment_by_fillet_length, CompoundSegment, FilletLength, TrimmedSegment
+        },
+        segment::Segment,
+        Fillet, FilletRadiusOption,
+    },
     misc::FloatingPoint,
     region::CompoundCurve,
 };
+
+type CompoundSegmentPreprocess<T, D> =
+    CompoundSegment<Segment<T, DimNameDiff<D, U1>>, NurbsCurve<T, D>>;
 
 impl<T: FloatingPoint, D: DimName> Fillet<FilletRadiusOption<T>> for CompoundCurve<T, D>
 where
@@ -23,31 +33,146 @@ where
     fn fillet(&self, option: FilletRadiusOption<T>) -> Self::Output {
         let radius = option.radius();
 
-        let spans = self
+        let segments = self
             .spans()
             .iter()
-            .map(|span| span.fillet(FilletRadiusOption::new(radius)))
-            .collect::<anyhow::Result<Vec<_>>>()?;
+            .flat_map(|c| {
+                if c.degree() > 1 {
+                    vec![CompoundSegment::Curve(c.clone())]
+                } else {
+                    let segments = decompose_into_segments(c);
+                    segments
+                        .into_iter()
+                        .map(|s| CompoundSegment::Segment(s))
+                        .collect_vec()
+                }
+            })
+            .collect_vec();
 
         let is_closed = self.is_closed(None);
+        let n = segments.len();
+        let m = if is_closed { n + 1 } else { n };
 
-        /*
-        // flatten the spans
-        let spans = spans.into_iter().flat_map(|c| c.into_spans()).collect_vec();
-        if is_closed {
-            let last = spans
-                .last()
-                .ok_or(anyhow::anyhow!("Closed curve must have at least one span"))?;
-            let head = spans
-                .first()
-                .ok_or(anyhow::anyhow!("Closed curve must have at least one span"))?;
-            if last.degree() == 1 && last.degree() == head.degree() {
-                // create fillet arc
-            }
-        }
-        Ok(CompoundCurve::new_unchecked_aligned(spans))
-        */
+        // calculate angle and fillet length for each segment
+        let half = T::from_f64(0.5).unwrap();
+        let eps = T::from_f64(1e-6).unwrap();
+        let angle_fillet_length = segments
+            .iter()
+            .cycle()
+            .take(m)
+            .collect_vec()
+            .windows(2)
+            .map(|w| match (w[0], w[1]) {
+                (CompoundSegment::Segment(s0), CompoundSegment::Segment(s1)) => {
+                    calculate_fillet_length(&[s0, s1], radius, |length| {
+                        let min = s0.length().min(s1.length());
+                        let l = min * half - eps;
+                        length.min(l)
+                    })
+                }
+                _ => None,
+            })
+            .collect_vec();
 
-        todo!()
+        fillet_compound_curve(segments, angle_fillet_length, is_closed)
     }
+}
+
+/// Fillet the sharp corners of the curve with a given radius
+fn fillet_compound_curve<T: FloatingPoint, D>(
+    segments: Vec<CompoundSegmentPreprocess<T, D>>,
+    angle_fillet_length: Vec<Option<FilletLength<T>>>,
+    is_closed: bool,
+) -> anyhow::Result<CompoundCurve<T, D>>
+where
+    D: DimName,
+    D: DimNameSub<U1>,
+    DefaultAllocator: Allocator<D>,
+    DefaultAllocator: Allocator<DimNameDiff<D, U1>>,
+    <D as DimNameSub<U1>>::Output: DimNameAdd<U1>,
+    DefaultAllocator: Allocator<<<D as DimNameSub<U1>>::Output as DimNameAdd<U1>>::Output>,
+{
+    let n = segments.len();
+    let m = if is_closed { n + 1 } else { n };
+    let l = angle_fillet_length.len();
+
+    let trimmed = segments
+        .into_iter()
+        .enumerate()
+        .map(|(i, current)| match current {
+            CompoundSegment::Segment(current) => {
+                let prev_fillet = if i != 0 || is_closed {
+                    angle_fillet_length[(i + l - 1) % l]
+                } else {
+                    None
+                };
+                let next_fillet = if i != n - 1 || is_closed {
+                    angle_fillet_length[i % l]
+                } else {
+                    None
+                };
+                let trimmed = trim_segment_by_fillet_length(&current, prev_fillet, next_fillet);
+                let s = TrimmedSegment::new(current, trimmed);
+                CompoundSegment::Segment(s)
+            }
+            CompoundSegment::Curve(c) => CompoundSegment::Curve(c.clone()),
+        })
+        .collect_vec();
+
+    let corners = trimmed
+        .iter()
+        .cycle()
+        .take(m)
+        .collect_vec()
+        .windows(2)
+        .zip(angle_fillet_length.into_iter())
+        .map(|(w, af)| {
+            let s0 = &w[0];
+            let s1 = &w[1];
+            match (s0, s1) {
+                (CompoundSegment::Segment(s0), CompoundSegment::Segment(s1)) => {
+                    create_fillet_corner_between_trimmed_segments(&[s0, s1], af)
+                }
+                _ => Ok(None),
+            }
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    let spans = trimmed
+        .into_iter()
+        .map(|s| match s {
+            CompoundSegment::Segment(s) => Some(CompoundSegment::Segment(s.trimmed().clone())),
+            CompoundSegment::Curve(c) => Some(CompoundSegment::Curve(c)),
+        })
+        .interleave(
+            corners
+                .into_iter()
+                .map(|c| c.map(|c| CompoundSegment::Curve(c))),
+        )
+        .collect_vec();
+
+    let mut curves = vec![];
+    let mut polyline = vec![];
+    for s in spans {
+        match s {
+            Some(CompoundSegment::Segment(s)) => {
+                polyline.push(s.start().clone());
+                polyline.push(s.end().clone());
+            }
+            Some(CompoundSegment::Curve(c)) => {
+                polyline.dedup();
+                curves.push(NurbsCurve::polyline(&polyline, false));
+                curves.push(c);
+                polyline.clear();
+            }
+            None => {}
+        }
+    }
+
+    if !polyline.is_empty() {
+        polyline.dedup();
+        curves.push(NurbsCurve::polyline(&polyline, false));
+    }
+
+    Ok(CompoundCurve::new_unchecked_aligned(curves))
 }

--- a/src/fillet/fillet_compound_curve.rs
+++ b/src/fillet/fillet_compound_curve.rs
@@ -1,0 +1,38 @@
+use itertools::Itertools;
+use nalgebra::{
+    allocator::Allocator, DefaultAllocator, DimName, DimNameAdd, DimNameDiff, DimNameSub, OPoint,
+    OVector, Rotation3, Unit, Vector3, U1,
+};
+
+use crate::{
+    curve::NurbsCurve,
+    fillet::{segment::Segment, Fillet, FilletRadiusOption, FilletRadiusParameterOption},
+    misc::FloatingPoint,
+    region::CompoundCurve,
+};
+
+impl<T: FloatingPoint, D: DimName> Fillet<FilletRadiusOption<T>> for CompoundCurve<T, D>
+where
+    D: DimNameSub<U1>,
+    DefaultAllocator: Allocator<D>,
+    DefaultAllocator: Allocator<DimNameDiff<D, U1>>,
+    <D as DimNameSub<U1>>::Output: DimNameAdd<U1>,
+    DefaultAllocator: Allocator<<<D as DimNameSub<U1>>::Output as DimNameAdd<U1>>::Output>,
+{
+    type Output = anyhow::Result<CompoundCurve<T, D>>;
+
+    /// Fillet the sharp corners of the curve with a given radius
+    fn fillet(&self, option: FilletRadiusOption<T>) -> Self::Output {
+        let radius = option.radius();
+
+        let spans = self
+            .spans()
+            .iter()
+            .map(|span| span.fillet(FilletRadiusOption::new(radius)))
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        let is_closed = self.is_closed(None);
+
+        todo!()
+    }
+}

--- a/src/fillet/fillet_compound_curve.rs
+++ b/src/fillet/fillet_compound_curve.rs
@@ -109,12 +109,10 @@ where
                 segment_index += index;
                 found = true;
                 break;
+            } else if span.degree() == 1 {
+                segment_index += span.control_points().len();
             } else {
-                if span.degree() == 1 {
-                    segment_index += span.control_points().len();
-                } else {
-                    segment_index += 1;
-                }
+                segment_index += 1;
             }
         }
 
@@ -181,7 +179,7 @@ where
                 let segments = decompose_into_segments(c);
                 segments
                     .into_iter()
-                    .map(|s| CompoundSegment::Segment(s))
+                    .map(CompoundSegment::Segment)
                     .collect_vec()
             }
         })
@@ -254,11 +252,7 @@ where
             CompoundSegment::Segment(s) => Some(CompoundSegment::Segment(s.trimmed().clone())),
             CompoundSegment::Curve(c) => Some(CompoundSegment::Curve(c)),
         })
-        .interleave(
-            corners
-                .into_iter()
-                .map(|c| c.map(|c| CompoundSegment::Curve(c))),
-        )
+        .interleave(corners.into_iter().map(|c| c.map(CompoundSegment::Curve)))
         .collect_vec();
 
     try_connect_compound_segments(spans)

--- a/src/fillet/fillet_compound_curve.rs
+++ b/src/fillet/fillet_compound_curve.rs
@@ -34,6 +34,11 @@ where
     /// Fillet the sharp corners of the curve with a given radius
     fn fillet(&self, option: FilletRadiusOption<T>) -> Self::Output {
         let radius = option.radius();
+        anyhow::ensure!(
+            radius > T::zero(),
+            "Radius must be positive, but got {}",
+            radius
+        );
 
         let segments = decompose_into_compound_segments(self);
 
@@ -78,8 +83,14 @@ where
 
     /// Only fillet the sharp corner at the specified parameter position with a given radius
     fn fillet(&self, option: FilletRadiusParameterOption<T>) -> Self::Output {
-        let parameter = option.parameter();
         let radius = option.radius();
+        anyhow::ensure!(
+            radius > T::zero(),
+            "Radius must be positive, but got {}",
+            radius
+        );
+
+        let parameter = option.parameter();
         let domain = self.knots_domain();
 
         anyhow::ensure!(
@@ -161,10 +172,11 @@ where
 }
 
 /// Decompose a compound curve into a list of segments and curves
-fn decompose_into_compound_segments<T: FloatingPoint, D: DimName>(
+fn decompose_into_compound_segments<T: FloatingPoint, D>(
     curve: &CompoundCurve<T, D>,
 ) -> Vec<CompoundSegmentPreprocess<T, D>>
 where
+    D: DimName,
     D: DimNameSub<U1>,
     DefaultAllocator: Allocator<D>,
     DefaultAllocator: Allocator<DimNameDiff<D, U1>>,

--- a/src/fillet/fillet_compound_curve.rs
+++ b/src/fillet/fillet_compound_curve.rs
@@ -29,10 +29,11 @@ where
             .map(|span| span.fillet(FilletRadiusOption::new(radius)))
             .collect::<anyhow::Result<Vec<_>>>()?;
 
+        let is_closed = self.is_closed(None);
+
+        /*
         // flatten the spans
         let spans = spans.into_iter().flat_map(|c| c.into_spans()).collect_vec();
-
-        let is_closed = self.is_closed(None);
         if is_closed {
             let last = spans
                 .last()
@@ -44,7 +45,9 @@ where
                 // create fillet arc
             }
         }
-
         Ok(CompoundCurve::new_unchecked_aligned(spans))
+        */
+
+        todo!()
     }
 }

--- a/src/fillet/fillet_nurbs_curve.rs
+++ b/src/fillet/fillet_nurbs_curve.rs
@@ -7,10 +7,9 @@ use crate::{
     curve::NurbsCurve,
     fillet::{
         helper::{
-            calculate_fillet_length, create_fillet_arc,
-            create_fillet_corner_between_trimmed_segments, decompose_into_segments,
-            trim_segment_by_fillet_length, try_connect_compound_segments, CompoundSegment,
-            FilletLength, TrimmedSegment,
+            calculate_fillet_length, create_fillet_corner_between_trimmed_segments,
+            decompose_into_segments, trim_segment_by_fillet_length, try_connect_compound_segments,
+            CompoundSegment, FilletLength, TrimmedSegment,
         },
         segment::Segment,
         Fillet, FilletRadiusOption, FilletRadiusParameterOption,
@@ -219,11 +218,7 @@ where
     let spans = trimmed
         .into_iter()
         .map(|s| Some(CompoundSegment::Segment(s.trimmed().clone())))
-        .interleave(
-            corners
-                .into_iter()
-                .map(|c| c.map(|c| CompoundSegment::Curve(c))),
-        )
+        .interleave(corners.into_iter().map(|c| c.map(CompoundSegment::Curve)))
         .collect_vec();
 
     try_connect_compound_segments(spans)

--- a/src/fillet/fillet_nurbs_curve.rs
+++ b/src/fillet/fillet_nurbs_curve.rs
@@ -6,73 +6,10 @@ use nalgebra::{
 
 use crate::{
     curve::NurbsCurve,
-    fillet::{segment::Segment, Fillet},
+    fillet::{segment::Segment, Fillet, FilletRadiusOption, FilletRadiusParameterOption},
     misc::FloatingPoint,
     region::CompoundCurve,
 };
-
-/// Fillet the sharp corners of the curve with a given radius
-#[derive(Debug, Clone, Copy)]
-pub struct FilletRadiusOption<T: FloatingPoint> {
-    radius: T,
-}
-
-impl<T: FloatingPoint> FilletRadiusOption<T> {
-    pub fn new(radius: T) -> Self {
-        Self { radius }
-    }
-
-    pub fn radius(&self) -> T {
-        self.radius
-    }
-}
-
-/// Only fillet the sharp corner at the specified parameter position with a given radius
-#[derive(Debug, Clone, Copy)]
-pub struct FilletRadiusParameterOption<T: FloatingPoint> {
-    radius: T,
-    parameter: T,
-}
-
-impl<T: FloatingPoint> FilletRadiusParameterOption<T> {
-    pub fn new(radius: T, parameter: T) -> Self {
-        Self { radius, parameter }
-    }
-
-    pub fn radius(&self) -> T {
-        self.radius
-    }
-
-    pub fn parameter(&self) -> T {
-        self.parameter
-    }
-
-    pub fn with_parameter(&mut self, parameter: T) -> &mut Self {
-        self.parameter = parameter;
-        self
-    }
-
-    pub fn with_radius(&mut self, radius: T) -> &mut Self {
-        self.radius = radius;
-        self
-    }
-}
-
-/// Fillet the sharp corners of the curve with a given distance
-#[derive(Debug, Clone, Copy)]
-pub struct FilletDistanceOption<T: FloatingPoint> {
-    distance: T,
-}
-
-impl<T: FloatingPoint> FilletDistanceOption<T> {
-    pub fn new(distance: T) -> Self {
-        Self { distance }
-    }
-
-    pub fn distance(&self) -> T {
-        self.distance
-    }
-}
 
 /// Span of a fillet curve
 #[derive(Debug, Clone)]

--- a/src/fillet/fillet_nurbs_curve.rs
+++ b/src/fillet/fillet_nurbs_curve.rs
@@ -54,7 +54,7 @@ where
         );
 
         let degree = self.degree();
-        if degree >= 2 || radius <= T::zero() {
+        if degree >= 2 {
             return Ok(self.clone().into());
         }
 
@@ -130,7 +130,7 @@ where
             parameter
         );
 
-        if degree >= 2 || radius <= T::zero() {
+        if degree >= 2 {
             return Ok(self.clone().into());
         }
 

--- a/src/fillet/fillet_nurbs_curve.rs
+++ b/src/fillet/fillet_nurbs_curve.rs
@@ -47,8 +47,13 @@ where
     /// ```
     fn fillet(&self, option: FilletRadiusOption<T>) -> Self::Output {
         let radius = option.radius();
-        let degree = self.degree();
+        anyhow::ensure!(
+            radius > T::zero(),
+            "Radius must be positive, but got {}",
+            radius
+        );
 
+        let degree = self.degree();
         if degree >= 2 || radius <= T::zero() {
             return Ok(self.clone().into());
         }
@@ -108,8 +113,14 @@ where
     /// let fillet = curve.fillet(FilletRadiusParameterOption::new(0.2, 2.)).unwrap();
     /// assert_eq!(fillet.spans().len(), 3);
     fn fillet(&self, option: FilletRadiusParameterOption<T>) -> Self::Output {
-        let degree = self.degree();
         let radius = option.radius();
+        anyhow::ensure!(
+            radius > T::zero(),
+            "Radius must be positive, but got {}",
+            radius
+        );
+
+        let degree = self.degree();
         let parameter = option.parameter();
         let domain = self.knots_domain();
 

--- a/src/fillet/fillet_nurbs_curve.rs
+++ b/src/fillet/fillet_nurbs_curve.rs
@@ -1,12 +1,15 @@
 use itertools::Itertools;
 use nalgebra::{
-    allocator::Allocator, DefaultAllocator, DimName, DimNameAdd, DimNameDiff, DimNameSub, OPoint,
-    OVector, Rotation3, Unit, Vector3, U1,
+    allocator::Allocator, DefaultAllocator, DimName, DimNameAdd, DimNameDiff, DimNameSub, U1,
 };
 
 use crate::{
     curve::NurbsCurve,
-    fillet::{segment::Segment, Fillet, FilletRadiusOption, FilletRadiusParameterOption},
+    fillet::{
+        helper::{calculate_fillet_length, create_fillet_arc, FilletLength},
+        segment::Segment,
+        Fillet, FilletRadiusOption, FilletRadiusParameterOption,
+    },
     misc::FloatingPoint,
     region::CompoundCurve,
 };
@@ -300,125 +303,6 @@ where
     }
 
     Ok(CompoundCurve::new_unchecked_aligned(curves))
-}
-
-type FilletLength<T> = (T, T, T);
-
-/// Calculate the fillet length for a given radius and segments
-fn calculate_fillet_length<T: FloatingPoint, D: DimName, F>(
-    w: &[&Segment<T, D>; 2],
-    radius: T,
-    constrain: F,
-) -> Option<FilletLength<T>>
-where
-    DefaultAllocator: Allocator<D>,
-    F: Fn(T) -> T,
-{
-    let half = T::from_f64(0.5).unwrap();
-
-    let s0 = &w[0];
-    let s1 = &w[1];
-    let t0 = s0.tangent();
-    let t1 = s1.tangent();
-    let cos_angle = t0.dot(t1).clamp(-T::one(), T::one());
-    let angle = cos_angle.acos();
-    if angle < T::from_f64(1e-4).unwrap() {
-        return None;
-    }
-    let half_angle = angle * half;
-
-    let tan_half = half_angle.tan();
-    let fillet_length = radius * tan_half;
-
-    let actual_fillet_length = constrain(fillet_length);
-
-    let actual_radius = actual_fillet_length / tan_half;
-    Some((angle, actual_fillet_length, actual_radius))
-}
-
-/// Create a fillet arc curve
-fn create_fillet_arc<T: FloatingPoint, D>(
-    start: &OPoint<T, DimNameDiff<D, U1>>,
-    corner: &OPoint<T, DimNameDiff<D, U1>>,
-    _end: &OPoint<T, DimNameDiff<D, U1>>,
-    t0: &OVector<T, DimNameDiff<D, U1>>,
-    t1: &OVector<T, DimNameDiff<D, U1>>,
-    angle: T,
-    radius: T,
-) -> anyhow::Result<NurbsCurve<T, D>>
-where
-    D: DimName,
-    D: DimNameSub<U1>,
-    DefaultAllocator: Allocator<D>,
-    DefaultAllocator: Allocator<DimNameDiff<D, U1>>,
-    <D as DimNameSub<U1>>::Output: DimNameAdd<U1>,
-    DefaultAllocator: Allocator<<<D as DimNameSub<U1>>::Output as DimNameAdd<U1>>::Output>,
-{
-    anyhow::ensure!(
-        D::dim() - 1 <= 3,
-        "Curve dimension must be less than or equal to 3, but got {}",
-        D::dim() - 1
-    );
-
-    let theta = angle / T::from_f64(2.0).unwrap();
-    let r = radius / theta.sin();
-
-    let bisector = (t1 - t0).normalize();
-    let center = corner + bisector * r;
-
-    let x_axis = (start - &center).normalize();
-
-    let t0_3d = to_3d_vector(t0).normalize();
-    let t1_3d = to_3d_vector(t1).normalize();
-    let rot = rotate_around_axis(&t0_3d, &t1_3d, T::frac_pi_2());
-
-    let dx = to_3d_vector(&x_axis);
-    let dy = rot * dx;
-    let y_axis = OVector::<T, DimNameDiff<D, U1>>::from_vec(dy.as_slice().to_vec());
-
-    let y_axis = if y_axis.dot(t0) < T::zero() {
-        -y_axis
-    } else {
-        y_axis
-    };
-
-    // debug
-    // return Ok(NurbsCurve::polyline( &vec![start.clone(), center.clone(), end.clone()], false,));
-    // return NurbsCurve::try_circle(&center, &x_axis, &y_axis, radius);
-    NurbsCurve::try_arc(
-        &center,
-        &x_axis,
-        &y_axis,
-        radius,
-        T::zero(),
-        T::pi() - angle.abs(),
-    )
-}
-
-/// Convert a 2d dimension vector to 3D vector
-/// if D is 2, return the vector with z = 0
-/// if D is 3, return the vector itself
-fn to_3d_vector<T: FloatingPoint, D: DimName>(v: &OVector<T, D>) -> Vector3<T>
-where
-    DefaultAllocator: Allocator<D>,
-{
-    if D::dim() == 2 {
-        Vector3::new(v[0], v[1], T::zero())
-    } else {
-        let v = v.as_slice().to_vec();
-        Vector3::new(v[0], v[1], v[2])
-    }
-}
-
-/// Rotate a vector around an axis
-fn rotate_around_axis<T: FloatingPoint>(
-    dx: &Vector3<T>,
-    dy: &Vector3<T>,
-    theta: T,
-) -> Rotation3<T> {
-    let n = dx.cross(dy).normalize();
-    let axis = Unit::new_normalize(n);
-    Rotation3::from_axis_angle(&axis, theta)
 }
 
 #[cfg(test)]

--- a/src/fillet/fillet_nurbs_curve.rs
+++ b/src/fillet/fillet_nurbs_curve.rs
@@ -6,7 +6,7 @@ use nalgebra::{
 use crate::{
     curve::NurbsCurve,
     fillet::{
-        helper::{calculate_fillet_length, create_fillet_arc, FilletLength},
+        helper::{calculate_fillet_length, create_fillet_arc, decompose_into_segments, FilletLength},
         segment::Segment,
         Fillet, FilletRadiusOption, FilletRadiusParameterOption,
     },
@@ -61,16 +61,7 @@ where
             return Ok(self.clone().into());
         }
 
-        let pts = self.dehomogenized_control_points();
-
-        let segments = pts
-            .windows(2)
-            .map(|w| {
-                let p0 = &w[0];
-                let p1 = &w[1];
-                Segment::new(p0.clone(), p1.clone())
-            })
-            .collect_vec();
+        let segments = decompose_into_segments(self);
 
         let is_closed = self.is_closed();
         let n = segments.len();
@@ -140,16 +131,7 @@ where
             return Ok(self.clone().into());
         }
 
-        let pts = self.dehomogenized_control_points();
-
-        let segments = pts
-            .windows(2)
-            .map(|w| {
-                let p0 = &w[0];
-                let p1 = &w[1];
-                Segment::new(p0.clone(), p1.clone())
-            })
-            .collect_vec();
+        let segments = decompose_into_segments(self);
 
         let is_closed = self.is_closed();
         let n = segments.len();
@@ -162,7 +144,7 @@ where
                 "Parameter must be in the domain of the curve, but got {}",
                 parameter
             ))?
-            .clamp(0, pts.len())
+            .clamp(0, segments.len() + 1)
             - 1;
 
         if !is_closed && index >= n - 1 {

--- a/src/fillet/helper.rs
+++ b/src/fillet/helper.rs
@@ -1,0 +1,125 @@
+use nalgebra::{
+    allocator::Allocator, DefaultAllocator, DimName, DimNameAdd, DimNameDiff, DimNameSub, OPoint,
+    OVector, Rotation3, Unit, Vector3, U1,
+};
+
+use crate::{curve::NurbsCurve, fillet::segment::Segment, misc::FloatingPoint};
+
+pub type FilletLength<T> = (T, T, T);
+
+/// Calculate the fillet length for a given radius and segments
+pub fn calculate_fillet_length<T: FloatingPoint, D: DimName, F>(
+    w: &[&Segment<T, D>; 2],
+    radius: T,
+    constrain: F,
+) -> Option<FilletLength<T>>
+where
+    DefaultAllocator: Allocator<D>,
+    F: Fn(T) -> T,
+{
+    let half = T::from_f64(0.5).unwrap();
+
+    let s0 = &w[0];
+    let s1 = &w[1];
+    let t0 = s0.tangent();
+    let t1 = s1.tangent();
+    let cos_angle = t0.dot(t1).clamp(-T::one(), T::one());
+    let angle = cos_angle.acos();
+    if angle < T::from_f64(1e-4).unwrap() {
+        return None;
+    }
+    let half_angle = angle * half;
+
+    let tan_half = half_angle.tan();
+    let fillet_length = radius * tan_half;
+
+    let actual_fillet_length = constrain(fillet_length);
+
+    let actual_radius = actual_fillet_length / tan_half;
+    Some((angle, actual_fillet_length, actual_radius))
+}
+
+/// Create a fillet arc curve
+pub fn create_fillet_arc<T: FloatingPoint, D>(
+    start: &OPoint<T, DimNameDiff<D, U1>>,
+    corner: &OPoint<T, DimNameDiff<D, U1>>,
+    _end: &OPoint<T, DimNameDiff<D, U1>>,
+    t0: &OVector<T, DimNameDiff<D, U1>>,
+    t1: &OVector<T, DimNameDiff<D, U1>>,
+    angle: T,
+    radius: T,
+) -> anyhow::Result<NurbsCurve<T, D>>
+where
+    D: DimName,
+    D: DimNameSub<U1>,
+    DefaultAllocator: Allocator<D>,
+    DefaultAllocator: Allocator<DimNameDiff<D, U1>>,
+    <D as DimNameSub<U1>>::Output: DimNameAdd<U1>,
+    DefaultAllocator: Allocator<<<D as DimNameSub<U1>>::Output as DimNameAdd<U1>>::Output>,
+{
+    anyhow::ensure!(
+        D::dim() - 1 <= 3,
+        "Curve dimension must be less than or equal to 3, but got {}",
+        D::dim() - 1
+    );
+
+    let theta = angle / T::from_f64(2.0).unwrap();
+    let r = radius / theta.sin();
+
+    let bisector = (t1 - t0).normalize();
+    let center = corner + bisector * r;
+
+    let x_axis = (start - &center).normalize();
+
+    let t0_3d = to_3d_vector(t0).normalize();
+    let t1_3d = to_3d_vector(t1).normalize();
+    let rot = rotate_around_axis(&t0_3d, &t1_3d, T::frac_pi_2());
+
+    let dx = to_3d_vector(&x_axis);
+    let dy = rot * dx;
+    let y_axis = OVector::<T, DimNameDiff<D, U1>>::from_vec(dy.as_slice().to_vec());
+
+    let y_axis = if y_axis.dot(t0) < T::zero() {
+        -y_axis
+    } else {
+        y_axis
+    };
+
+    // debug
+    // return Ok(NurbsCurve::polyline( &vec![start.clone(), center.clone(), end.clone()], false,));
+    // return NurbsCurve::try_circle(&center, &x_axis, &y_axis, radius);
+    NurbsCurve::try_arc(
+        &center,
+        &x_axis,
+        &y_axis,
+        radius,
+        T::zero(),
+        T::pi() - angle.abs(),
+    )
+}
+
+/// Convert a 2d dimension vector to 3D vector
+/// if D is 2, return the vector with z = 0
+/// if D is 3, return the vector itself
+fn to_3d_vector<T: FloatingPoint, D: DimName>(v: &OVector<T, D>) -> Vector3<T>
+where
+    DefaultAllocator: Allocator<D>,
+{
+    if D::dim() == 2 {
+        Vector3::new(v[0], v[1], T::zero())
+    } else {
+        let v = v.as_slice().to_vec();
+        Vector3::new(v[0], v[1], v[2])
+    }
+}
+
+/// Rotate a vector around an axis
+fn rotate_around_axis<T: FloatingPoint>(
+    dx: &Vector3<T>,
+    dy: &Vector3<T>,
+    theta: T,
+) -> Rotation3<T> {
+    let n = dx.cross(dy).normalize();
+    let axis = Unit::new_normalize(n);
+    Rotation3::from_axis_angle(&axis, theta)
+}

--- a/src/fillet/helper.rs
+++ b/src/fillet/helper.rs
@@ -7,6 +7,23 @@ use crate::{curve::NurbsCurve, fillet::segment::Segment, misc::FloatingPoint};
 
 pub type FilletLength<T> = (T, T, T);
 
+/// Decompose a curve into segments
+pub fn decompose_into_segments<T: FloatingPoint, D: DimName>(
+    curve: &NurbsCurve<T, D>,
+) -> Vec<Segment<T, DimNameDiff<D, U1>>>
+where
+    D: DimNameSub<U1>,
+    DefaultAllocator: Allocator<D>,
+    DefaultAllocator: Allocator<DimNameDiff<D, U1>>,
+{
+    let pts = curve.dehomogenized_control_points();
+    pts.windows(2).map(|w| {
+        let p0 = &w[0];
+        let p1 = &w[1];
+        Segment::new(p0.clone(), p1.clone())
+    }).collect()
+}
+
 /// Calculate the fillet length for a given radius and segments
 pub fn calculate_fillet_length<T: FloatingPoint, D: DimName, F>(
     w: &[&Segment<T, D>; 2],

--- a/src/fillet/helper.rs
+++ b/src/fillet/helper.rs
@@ -42,10 +42,11 @@ pub enum CompoundSegment<S, C> {
 }
 
 /// Decompose a curve into segments
-pub fn decompose_into_segments<T: FloatingPoint, D: DimName>(
+pub fn decompose_into_segments<T: FloatingPoint, D>(
     curve: &NurbsCurve<T, D>,
 ) -> Vec<Segment<T, DimNameDiff<D, U1>>>
 where
+    D: DimName,
     D: DimNameSub<U1>,
     DefaultAllocator: Allocator<D>,
     DefaultAllocator: Allocator<DimNameDiff<D, U1>>,
@@ -93,12 +94,13 @@ where
 }
 
 /// Trim a segment by a given length
-pub fn trim_segment_by_fillet_length<T: FloatingPoint, D: DimName>(
+pub fn trim_segment_by_fillet_length<T: FloatingPoint, D>(
     segment: &Segment<T, D>,
     prev_fillet: Option<FilletLength<T>>,
     next_fillet: Option<FilletLength<T>>,
 ) -> Segment<T, D>
 where
+    D: DimName,
     DefaultAllocator: Allocator<D>,
 {
     let start = match prev_fillet {
@@ -114,7 +116,7 @@ where
 }
 
 /// Create a fillet corner curve
-pub fn create_fillet_corner_between_trimmed_segments<T: FloatingPoint, D: DimName>(
+pub fn create_fillet_corner_between_trimmed_segments<T: FloatingPoint, D>(
     segments: &[&TrimmedSegment<T, DimNameDiff<D, U1>>; 2],
     fillet_length: Option<FilletLength<T>>,
 ) -> anyhow::Result<Option<NurbsCurve<T, D>>>
@@ -207,10 +209,12 @@ where
 }
 
 /// Connect a list of compound segments into a compound curve
-pub fn try_connect_compound_segments<T: FloatingPoint, D: DimName>(
+#[allow(clippy::type_complexity)]
+pub fn try_connect_compound_segments<T: FloatingPoint, D>(
     segments: Vec<Option<CompoundSegment<Segment<T, DimNameDiff<D, U1>>, NurbsCurve<T, D>>>>,
 ) -> anyhow::Result<CompoundCurve<T, D>>
 where
+    D: DimName,
     D: DimNameSub<U1>,
     DefaultAllocator: Allocator<D>,
     DefaultAllocator: Allocator<DimNameDiff<D, U1>>,

--- a/src/fillet/mod.rs
+++ b/src/fillet/mod.rs
@@ -2,12 +2,9 @@ pub mod curve_fillet_option;
 pub mod fillet_compound_curve;
 pub mod fillet_nurbs_curve;
 pub use curve_fillet_option::*;
-pub use fillet_compound_curve::*;
-pub use fillet_nurbs_curve::*;
 
+mod helper;
 mod segment;
-
-use crate::misc::FloatingPoint;
 
 /// Trait for filleting a geometry
 /// O is the option type for the fillet

--- a/src/fillet/mod.rs
+++ b/src/fillet/mod.rs
@@ -1,6 +1,13 @@
+pub mod curve_fillet_option;
+pub mod fillet_compound_curve;
 pub mod fillet_nurbs_curve;
-mod segment;
+pub use curve_fillet_option::*;
+pub use fillet_compound_curve::*;
 pub use fillet_nurbs_curve::*;
+
+mod segment;
+
+use crate::misc::FloatingPoint;
 
 /// Trait for filleting a geometry
 /// O is the option type for the fillet


### PR DESCRIPTION
This pull request introduces significant enhancements to the `curvo` library, focusing on the implementation of filleting options for curves and adding a new example to demonstrate these features. It also includes updates to dependencies and minor adjustments to existing code.

### Enhancements to Curve Filleting:

* [`src/fillet/curve_fillet_option.rs`](diffhunk://#diff-9d64afb051aec53a48c7464757c6b26a1eff69ffd5fe856cb57078d994611f50R1-R64): Added new structs `FilletRadiusOption`, `FilletRadiusParameterOption`, and `FilletDistanceOption` to encapsulate filleting parameters. These options allow filleting sharp corners of curves with a radius or distance, or at specific parameter positions.
* [`src/fillet/fillet_compound_curve.rs`](diffhunk://#diff-f58b9691ffdb0dd39c49449c14523058b05391fe466ab866a8547d430c8e6c02R1-R311): Implemented filleting functionality for compound curves using the newly added options. This includes methods to decompose curves into segments, calculate fillet lengths, and create filleted corners.
* [`src/fillet/fillet_nurbs_curve.rs`](diffhunk://#diff-917454e77b0e4a17cb293d5277f15a69bdd3ae4535cc5ed9d26c66a40bf38b43L3-L88): Refactored filleting logic for NURBS curves to utilize shared helper functions and the new filleting options. Removed redundant code for filleting options and span definitions.

### New Example for Compound Curve Filleting:

* [`examples/fillet_compound_curve.rs`](diffhunk://#diff-d262762e8170094df5c4c779811cd2735c9bd0d64fc876b8da1e06a0a78d799dR1-R261): Added a new example demonstrating the use of filleting options on compound curves. The example includes interactive UI elements for adjusting fillet parameters and visualizing control points and tessellated curves.

### Dependency Updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L23-R23): Updated the version of the `spade` dependency from `2.13.1` to `2.14.0`. This ensures compatibility with the latest features and fixes.

### Minor Adjustments:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3): Incremented the package version from `0.1.57` to `0.1.58` to reflect the new features added in this pull request.
* [`examples/fillet_curve.rs`](diffhunk://#diff-006dd4d1a43e7aa6c6add66c0167a8364dfee77f1e049ef581568b08819613c5L269-R270): Adjusted the UI drag speed for the `parameter` setting from `1e-2` to `1e-1` for smoother interaction.