### PR TITLE
0.1.60

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2071,7 +2071,7 @@ checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 
 [[package]]
 name = "curvo"
-version = "0.1.59"
+version = "0.1.60"
 dependencies = [
  "anyhow",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curvo"
-version = "0.1.59"
+version = "0.1.60"
 authors = ["Masatatsu Nakamura <masatatsu.nakamura@gmail.com"]
 edition = "2021"
 keywords = ["nurbs", "modeling", "graphics", "3d"]

--- a/examples/fillet_compound_curve.rs
+++ b/examples/fillet_compound_curve.rs
@@ -108,7 +108,7 @@ fn setup(mut commands: Commands, settings: Res<Setting>) {
     let _curve = CompoundCurve::try_new(spans).unwrap();
 
     if settings.use_parameter {
-        let option = FilletRadiusParameterOption::new(settings.radius, settings.parameter);
+        let option = FilletRadiusParameterOption::new(settings.radius, vec![settings.parameter]);
         let fillet_curve = curve.fillet(option).unwrap();
         commands.spawn((FilletCurve(fillet_curve),));
     } else {
@@ -199,7 +199,8 @@ fn update_ui(
         let mut fillet_curve = fillet_curve.single_mut().unwrap();
 
         if settings.use_parameter {
-            let option = FilletRadiusParameterOption::new(settings.radius, settings.parameter);
+            let option =
+                FilletRadiusParameterOption::new(settings.radius, vec![settings.parameter]);
             let res = profile.0.fillet(option);
             if let Ok(res) = res {
                 fillet_curve.0 = res;

--- a/examples/fillet_curve.rs
+++ b/examples/fillet_curve.rs
@@ -161,7 +161,7 @@ fn setup(mut commands: Commands, settings: Res<Setting>) {
     let curve = NurbsCurve2D::polyline(&points, false);
 
     if settings.use_parameter {
-        let option = FilletRadiusParameterOption::new(settings.radius, settings.parameter);
+        let option = FilletRadiusParameterOption::new(settings.radius, vec![settings.parameter]);
         let fillet_curve = curve.fillet(option).unwrap();
         commands.spawn((FilletCurve(fillet_curve),));
     } else {
@@ -186,7 +186,7 @@ fn setup(mut commands: Commands, settings: Res<Setting>) {
     );
 
     if settings.use_parameter {
-        let option = FilletRadiusParameterOption::new(settings.radius, settings.parameter);
+        let option = FilletRadiusParameterOption::new(settings.radius, vec![settings.parameter]);
         let fillet_curve = curve.fillet(option).unwrap();
         commands.spawn((Fillet3DCurve(fillet_curve),));
     } else {
@@ -289,18 +289,19 @@ fn update_ui(
         let mut fillet_curve_3d = fillet_curve_3d.single_mut().unwrap();
 
         if settings.use_parameter {
-            let option = FilletRadiusParameterOption::new(settings.radius, settings.parameter);
-            let res = profile.0.fillet(option);
+            let option =
+                FilletRadiusParameterOption::new(settings.radius, vec![settings.parameter]);
+            let res = profile.0.fillet(option.clone());
             if let Ok(res) = res {
                 fillet_curve.0 = res;
             }
-            let res = profile_3d.0.fillet(option);
+            let res = profile_3d.0.fillet(option.clone());
             if let Ok(res) = res {
                 fillet_curve_3d.0 = res;
             }
         } else {
             let option = FilletRadiusOption::new(settings.radius);
-            let res = profile.0.fillet(option);
+            let res = profile.0.fillet(option.clone());
             if let Ok(res) = res {
                 fillet_curve.0 = res;
             }

--- a/src/fillet/curve_fillet_option.rs
+++ b/src/fillet/curve_fillet_option.rs
@@ -16,28 +16,40 @@ impl<T: FloatingPoint> FilletRadiusOption<T> {
     }
 }
 
-/// Only fillet the sharp corner at the specified parameter position with a given radius
-#[derive(Debug, Clone, Copy)]
+/// Only fillet the sharp corners at the specified parameter positions with a given radius
+#[derive(Debug, Clone)]
 pub struct FilletRadiusParameterOption<T: FloatingPoint> {
     radius: T,
-    parameter: T,
+    parameters: Vec<T>,
 }
 
 impl<T: FloatingPoint> FilletRadiusParameterOption<T> {
-    pub fn new(radius: T, parameter: T) -> Self {
-        Self { radius, parameter }
+    pub fn new(radius: T, parameters: Vec<T>) -> Self {
+        Self { radius, parameters }
+    }
+
+    pub fn from_single(radius: T, parameter: T) -> Self {
+        Self {
+            radius,
+            parameters: vec![parameter],
+        }
     }
 
     pub fn radius(&self) -> T {
         self.radius
     }
 
-    pub fn parameter(&self) -> T {
-        self.parameter
+    pub fn parameters(&self) -> &[T] {
+        &self.parameters
     }
 
-    pub fn with_parameter(&mut self, parameter: T) -> &mut Self {
-        self.parameter = parameter;
+    pub fn with_parameters(&mut self, parameters: Vec<T>) -> &mut Self {
+        self.parameters = parameters;
+        self
+    }
+
+    pub fn add_parameter(&mut self, parameter: T) -> &mut Self {
+        self.parameters.push(parameter);
         self
     }
 


### PR DESCRIPTION
This pull request introduces changes to enhance the flexibility of fillet operations by allowing multiple parameter positions instead of a single one. It modifies the `FilletRadiusParameterOption` structure and updates its usage across various files to support this functionality. Additionally, it improves parameter validation and handling in fillet calculations.

### Enhancements to `FilletRadiusParameterOption`:

* [`src/fillet/curve_fillet_option.rs`](diffhunk://#diff-9d64afb051aec53a48c7464757c6b26a1eff69ffd5fe856cb57078d994611f50L19-R52): Updated `FilletRadiusParameterOption` to use a `Vec<T>` for multiple parameter positions instead of a single parameter. Added new methods (`from_single`, `parameters`, `with_parameters`, and `add_parameter`) to facilitate working with multiple parameters.

### Updates to fillet operations in examples:

* [`examples/fillet_compound_curve.rs`](diffhunk://#diff-d262762e8170094df5c4c779811cd2735c9bd0d64fc876b8da1e06a0a78d799dL111-R111): Updated fillet operations to use `vec![settings.parameter]` for creating `FilletRadiusParameterOption` instances in both `setup` and `update_ui` functions. [[1]](diffhunk://#diff-d262762e8170094df5c4c779811cd2735c9bd0d64fc876b8da1e06a0a78d799dL111-R111) [[2]](diffhunk://#diff-d262762e8170094df5c4c779811cd2735c9bd0d64fc876b8da1e06a0a78d799dL202-R203)
* [`examples/fillet_curve.rs`](diffhunk://#diff-006dd4d1a43e7aa6c6add66c0167a8364dfee77f1e049ef581568b08819613c5L164-R164): Made similar updates to `setup` and `update_ui` functions to support multiple parameters for fillet operations. [[1]](diffhunk://#diff-006dd4d1a43e7aa6c6add66c0167a8364dfee77f1e049ef581568b08819613c5L164-R164) [[2]](diffhunk://#diff-006dd4d1a43e7aa6c6add66c0167a8364dfee77f1e049ef581568b08819613c5L189-R189) [[3]](diffhunk://#diff-006dd4d1a43e7aa6c6add66c0167a8364dfee77f1e049ef581568b08819613c5L292-R304)

### Improvements to fillet calculations:

* [`src/fillet/fillet_compound_curve.rs`](diffhunk://#diff-f58b9691ffdb0dd39c49449c14523058b05391fe466ab866a8547d430c8e6c02L133-R154): Enhanced fillet logic to validate all parameters against the curve domain and calculate segment indices for multiple parameters. Updated the fillet length calculation to handle multiple indices. [[1]](diffhunk://#diff-f58b9691ffdb0dd39c49449c14523058b05391fe466ab866a8547d430c8e6c02L133-R154) [[2]](diffhunk://#diff-f58b9691ffdb0dd39c49449c14523058b05391fe466ab866a8547d430c8e6c02R188-R191) [[3]](diffhunk://#diff-f58b9691ffdb0dd39c49449c14523058b05391fe466ab866a8547d430c8e6c02L193-R203)
* [`src/fillet/fillet_nurbs_curve.rs`](diffhunk://#diff-917454e77b0e4a17cb293d5277f15a69bdd3ae4535cc5ed9d26c66a40bf38b43L124-R134): Similar improvements for fillet operations on NURBS curves, including validation of multiple parameters, calculation of indices, and handling indices in fillet length calculations. [[1]](diffhunk://#diff-917454e77b0e4a17cb293d5277f15a69bdd3ae4535cc5ed9d26c66a40bf38b43L124-R134) [[2]](diffhunk://#diff-917454e77b0e4a17cb293d5277f15a69bdd3ae4535cc5ed9d26c66a40bf38b43R146-R149) [[3]](diffhunk://#diff-917454e77b0e4a17cb293d5277f15a69bdd3ae4535cc5ed9d26c66a40bf38b43R163-R165) [[4]](diffhunk://#diff-917454e77b0e4a17cb293d5277f15a69bdd3ae4535cc5ed9d26c66a40bf38b43L166-R176)

### Documentation updates:

* Updated code examples in `src/fillet/fillet_compound_curve.rs` and `src/fillet/fillet_nurbs_curve.rs` to reflect the new `FilletRadiusParameterOption` structure using `vec![]` for parameters. [[1]](diffhunk://#diff-f58b9691ffdb0dd39c49449c14523058b05391fe466ab866a8547d430c8e6c02L122-R122) [[2]](diffhunk://#diff-917454e77b0e4a17cb293d5277f15a69bdd3ae4535cc5ed9d26c66a40bf38b43L113-R113)