### PR TITLE
Inverse the default impl for the `boolean` method of the `Boolean` trait strategy

### DIFF
--- a/src/boolean/mod.rs
+++ b/src/boolean/mod.rs
@@ -17,17 +17,11 @@ pub trait Boolean<T> {
     type Output;
     type Option;
 
-    fn union(&self, other: T, option: Self::Option) -> Self::Output {
-        self.boolean(BooleanOperation::Union, other, option)
-    }
+    fn union(&self, other: T, option: Self::Option) -> Self::Output;
 
-    fn intersection(&self, other: T, option: Self::Option) -> Self::Output {
-        self.boolean(BooleanOperation::Intersection, other, option)
-    }
+    fn intersection(&self, other: T, option: Self::Option) -> Self::Output;
 
-    fn difference(&self, other: T, option: Self::Option) -> Self::Output {
-        self.boolean(BooleanOperation::Difference, other, option)
-    }
+    fn difference(&self, other: T, option: Self::Option) -> Self::Output;
 
     fn boolean(&self, operation: BooleanOperation, other: T, option: Self::Option) -> Self::Output {
         match operation {

--- a/src/boolean/mod.rs
+++ b/src/boolean/mod.rs
@@ -29,7 +29,13 @@ pub trait Boolean<T> {
         self.boolean(BooleanOperation::Difference, other, option)
     }
 
-    fn boolean(&self, operation: BooleanOperation, other: T, option: Self::Option) -> Self::Output;
+    fn boolean(&self, operation: BooleanOperation, other: T, option: Self::Option) -> Self::Output {
+        match operation {
+            BooleanOperation::Union => self.union(other, option),
+            BooleanOperation::Intersection => self.intersection(other, option),
+            BooleanOperation::Difference => self.difference(other, option),
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Add default impl for the `boolean` method of the `Boolean` trait, while removing the defaults for the other methods to encourage spliting the impls in to there own functions.