### PR TITLE
0.1.63

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2071,7 +2071,7 @@ checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 
 [[package]]
 name = "curvo"
-version = "0.1.62"
+version = "0.1.63"
 dependencies = [
  "anyhow",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curvo"
-version = "0.1.62"
+version = "0.1.63"
 authors = ["Masatatsu Nakamura <masatatsu.nakamura@gmail.com"]
 edition = "2021"
 keywords = ["nurbs", "modeling", "graphics", "3d"]

--- a/src/fillet/fillet_nurbs_curve.rs
+++ b/src/fillet/fillet_nurbs_curve.rs
@@ -128,6 +128,25 @@ where
 {
     type Output = anyhow::Result<CompoundCurve<T, D>>;
 
+    /// Only fillet the sharp corner at the specified parameter position with a given radius
+    /// # Example
+    /// ```
+    /// use nalgebra::Point2;
+    /// use curvo::prelude::*;
+    ///
+    /// let square = vec![
+    ///     Point2::new(-1.0, -1.0),
+    ///     Point2::new(1.0, -1.0),
+    ///     Point2::new(1.0, 1.0),
+    ///     Point2::new(-1.0, 1.0),
+    ///     Point2::new(-1.0, -1.0),
+    /// ];
+    /// let curve = NurbsCurve2D::polyline(&square, false);
+    /// let fillet = curve.fillet(FilletRadiusParameterSetOption::new(vec![
+    ///     FilletRadiusParameterSet::new(2.0, 0.5),
+    /// ])).unwrap();
+    /// assert_eq!(fillet.spans().len(), 3);
+    /// ```
     fn fillet(&self, option: FilletRadiusParameterSetOption<T>) -> Self::Output {
         let sets = option.radius_parameter_sets();
         anyhow::ensure!(

--- a/src/surface/nurbs_surface.rs
+++ b/src/surface/nurbs_surface.rs
@@ -26,7 +26,7 @@ use super::{FlipDirection, UVDirection};
 
 /// NURBS surface representation
 /// by generics, it can be used for 2D or 3D curves with f32 or f64 scalar types
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct NurbsSurface<T: FloatingPoint, D: DimName>
 where
     DefaultAllocator: Allocator<D>,

--- a/src/surface/trimmed_surface.rs
+++ b/src/surface/trimmed_surface.rs
@@ -14,7 +14,7 @@ use super::NurbsSurface3D;
 
 /// A trimmed NURBS surface.
 /// Base surface & a set of trimming curves in parameter space
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TrimmedSurface<T: FloatingPoint> {
     surface: NurbsSurface3D<T>,
     exterior: Option<CompoundCurve<T, U3>>,


### PR DESCRIPTION
This pull request introduces several changes to enhance functionality, improve maintainability, and update metadata in the `curvo` library. The most significant updates include a version bump in the `Cargo.toml`, the addition of a new example in the `fillet` function documentation, and the inclusion of the `PartialEq` trait for key structs.

### Metadata Update:
* Updated the package version in `Cargo.toml` from `0.1.62` to `0.1.63`, likely indicating a minor update with new features or improvements.

### Documentation Improvement:
* Added a detailed example to the `fillet` function in `src/fillet/fillet_nurbs_curve.rs`, demonstrating its usage with a `NurbsCurve2D` and the `FilletRadiusParameterSetOption`. This improves usability by providing a clear reference for developers.

### Codebase Enhancements:
* Added the `PartialEq` trait to the `NurbsSurface` struct in `src/surface/nurbs_surface.rs`, enabling equality comparisons for instances of this struct.
* Added the `PartialEq` trait to the `TrimmedSurface` struct in `src/surface/trimmed_surface.rs`, similarly allowing equality checks for instances of this struct.