### PR TITLE
0.1.68

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2572,9 +2572,9 @@ dependencies = [
 
 [[package]]
 name = "geo"
-version = "0.29.3"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f0e6e028c581e82e6822a68869514e94c25e7f8ea669a2d8595bdf7461ccc5"
+checksum = "4416397671d8997e9a3e7ad99714f4f00a22e9eaa9b966a5985d2194fc9e02e1"
 dependencies = [
  "earcutr",
  "float_next_after",
@@ -3005,9 +3005,9 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "i_float"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775f9961a8d2f879725da8aff789bb20a3ddf297473e0c90af75e69313919490"
+checksum = "85df3a416829bb955fdc2416c7b73680c8dcea8d731f2c7aa23e1042fe1b8343"
 dependencies = [
  "serde",
 ]
@@ -3020,9 +3020,9 @@ checksum = "347c253b4748a1a28baf94c9ce133b6b166f08573157e05afe718812bc599fcd"
 
 [[package]]
 name = "i_overlay"
-version = "1.9.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01882ce5ed786bf6e8f5167f171a4026cd129ce17d9ff5cbf1e6749b98628ece"
+checksum = "0542dfef184afdd42174a03dcc0625b6147fb73e1b974b1a08a2a42ac35cee49"
 dependencies = [
  "i_float",
  "i_key_sort",
@@ -3033,9 +3033,9 @@ dependencies = [
 
 [[package]]
 name = "i_shape"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27dbe9e5238d6b9c694c08415bf00fb370b089949bd818ab01f41f8927b8774c"
+checksum = "0a38f5a42678726718ff924f6d4a0e79b129776aeed298f71de4ceedbd091bce"
 dependencies = [
  "i_float",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2071,7 +2071,7 @@ checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
 name = "curvo"
-version = "0.1.67"
+version = "0.1.68"
 dependencies = [
  "anyhow",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curvo"
-version = "0.1.67"
+version = "0.1.68"
 authors = ["Masatatsu Nakamura <masatatsu.nakamura@gmail.com"]
 edition = "2021"
 keywords = ["nurbs", "modeling", "graphics", "3d"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ easer = { version = "0.3.0", optional = true }
 simba = { version = "0.9.0", default-features = false }
 spade = { version = "2.15.0" }
 gauss-quad = "0.2.4"
-geo = { version = "0.29.3" }
+geo = { version = "0.30.0" }
 bevy = { version = "0.16.1", optional = true }
 bevy_egui = { version = "0.34.1", optional = true }
 bevy_infinite_grid = { version = "0.15.0", optional = true }


### PR DESCRIPTION
This pull request updates the `curvo` crate to use newer dependencies and bumps the crate version. The main change is upgrading the `geo` crate to a newer version, which may bring bug fixes or new features.

Dependency updates:

* Bumped the `geo` dependency from version `0.29.3` to `0.30.0` in `Cargo.toml`.

Version bump:

* Updated the crate version from `0.1.67` to `0.1.68` in `Cargo.toml`.